### PR TITLE
LAM-25 Script that runs random tweet generator and sends output to Kafka

### DIFF
--- a/kafka_producer_scripts/README.md
+++ b/kafka_producer_scripts/README.md
@@ -1,0 +1,17 @@
+# lambda instance demo
+
+## Kafka data producer
+
+Runs random tweet generator script (currently placed in /root/data-generator.py), and sends the output to the Kafka topic "input-tweets".
+
+### Prerequisites
+
+- Run on Debian 8.0 node
+- Python and Kafka must be installed
+- data-generator.py must be placed in /root
+
+### How to run
+
+Create (touch) a file named "runrand" in root.
+Run the rand_kafka_producer.sh
+The script will run until the runrand file is deleted, producing random tweets every second.

--- a/kafka_producer_scripts/rand_kafka_producer.sh
+++ b/kafka_producer_scripts/rand_kafka_producer.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 while [ -f "/root/runrand" ]; do
-   python /root/data-generator.py | /usr/lib/kafka_2.10-0.8.2.1/bin/kafka-console-producer.sh --broker-list snf-661306:9092 --topic input-tweets
+   python /root/data-generator.py | /usr/lib/kafka_2.10-0.8.2.1/bin/kafka-console-producer.sh --broker-list 192.168.0.3:9092 --topic input
    sleep 1
 done
 

--- a/kafka_producer_scripts/rand_kafka_producer.sh
+++ b/kafka_producer_scripts/rand_kafka_producer.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+while [ -f "/root/runrand" ]; do
+   python /root/data-generator.py | /usr/lib/kafka_2.10-0.8.2.1/bin/kafka-console-producer.sh --broker-list snf-661306:9092 --topic input-tweets
+   sleep 1
+done
+

--- a/kafka_producer_scripts/rand_kafka_producer.sh
+++ b/kafka_producer_scripts/rand_kafka_producer.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 while [ -f "/root/runrand" ]; do
-   python /root/data-generator.py | /usr/lib/kafka_2.10-0.8.2.1/bin/kafka-console-producer.sh --broker-list 192.168.0.3:9092 --topic input
+   python /root/data-generator.py | /usr/local/kafka/bin/kafka-console-producer.sh --broker-list 192.168.0.3:9092 --topic input
    sleep 1
 done
 


### PR DESCRIPTION
This commit contains a script that runs the random tweet generator script (currently placed in /root/data-generator.py) every second, and sends the output to the Kafka topic "input-tweets".
