### PR TITLE
Divided Provisioner functionality in ProvisionerBase (parent) and Pro…

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -66,6 +66,8 @@ Note that you may retrieve your ~okeanos API token, after logging into the servi
 
 To create a lambda instance, one must run `python lambda_instance_manager.py` from within the `core/fokia` directory. To change the default settings (one master instance and one slave instance) one has to edit the `lambda_instance_manager.py` script prior to executing it.
 
+**Note:** The intended use described above is **only** for when run from the service vm.
+For development purposes, uncomment the `script_path` commented out and import `os` and `inspect` libs.
 
 
 ## Testing

--- a/core/fokia/lambda_instance_manager.py
+++ b/core/fokia/lambda_instance_manager.py
@@ -1,6 +1,9 @@
 import time
 from fokia.provisioner import Provisioner
 from fokia.ansible_manager import Manager
+# import os
+# import inspect
+
 # script_path = os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe())))
 script_path = '/var/www/okeanos-LoD/core/fokia'
 

--- a/core/fokia/provisioner.py
+++ b/core/fokia/provisioner.py
@@ -14,109 +14,23 @@ from fokia.cluster_error_constants import *
 from Crypto.PublicKey import RSA
 from base64 import b64encode
 
+from fokia.provisioner_base import ProvisionerBase
+
+
 storage_templates = ['drdb', 'ext_vlmc']
 
-class Provisioner:
+class Provisioner(ProvisionerBase):
     """
         provisions virtual machines on ~okeanos
     """
 
     def __init__(self, auth_token, cloud_name=None):
 
-        if auth_token is None and cloud_name is not None:
-
-            # Load .kamakirc configuration
-            logger.info("Retrieving .kamakirc configuration")
-            self.config = KamakiConfig()
-            patch_certs(self.config.get('global', 'ca_certs'))
-            cloud_section = self.config._sections['cloud'].get(cloud_name)
-            if not cloud_section:
-                message = "Cloud '%s' was not found in you .kamakirc configuration file. " \
-                          "Currently you have availablie in your configuration these clouds: %s"
-                raise KeyError(message % (cloud_name, self.config._sections['cloud'].keys()))
-
-            # Get the authentication url and token
-            auth_url, auth_token = cloud_section['url'], cloud_section['token']
-
-        else:
-            auth_url = "https://accounts.okeanos.grnet.gr/identity/v2.0"
-
-        logger.info("Initiating Astakos Client")
-        self.astakos = astakos.AstakosClient(auth_url, auth_token)
-
-        logger.info("Retrieving cyclades endpoint url")
-        compute_url = self.astakos.get_endpoint_url(
-            cyclades.CycladesComputeClient.service_type)
-        logger.info("Initiating Cyclades client")
-        self.cyclades = cyclades.CycladesComputeClient(compute_url, auth_token)
-
-        # Create the network client
-        networkURL = self.astakos.get_endpoint_url(
-            cyclades.CycladesNetworkClient.service_type)
-        self.network_client = cyclades.CycladesNetworkClient(networkURL, auth_token)
-
-        # Constants
-        self.Bytes_to_GB = 1024 * 1024 * 1024
-        self.Bytes_to_MB = 1024 * 1024
-
+        #super(C,self).__init__()
+        super(Provisioner, self).__init__(auth_token=auth_token, cloud_name=cloud_name)
         self.master = None
-        self.ips = None
         self.slaves = None
-        self.vpn = None
-        self.subnet = None
-        self.private_key = None
-        self.image_id = 'c6f5adce-21ad-4ce3-8591-acfe7eb73c02'
-
-    """
-    FIND RESOURCES
-    """
-
-    def find_flavor(self, **kwargs):
-        """
-
-        :param kwargs: should contains the keys that specify the specs
-        :return: first flavor objects that matches the specs criteria
-        """
-
-        # Set all the default parameters
-        kwargs.setdefault("vcpus", 1)
-        kwargs.setdefault("ram", 1024)
-        kwargs.setdefault("disk", 40)
-        kwargs.setdefault("SNF:allow_create", True)
-        logger.info("Retrieving flavor")
-        for flavor in self.cyclades.list_flavors(detail=True):
-            if all([kwargs[key] == flavor[key]
-                    for key in set(flavor.keys()).intersection(kwargs.keys())]):
-                return flavor
-        return None
-
-    def find_image(self, **kwargs):
-        """
-        :param image_name: Name of the image to filter by
-        :param kwargs:
-        :return: first image object that matches the name criteria
-        """
-        image_name = kwargs['image_name']
-
-        logger.info("Retrieving image")
-        for image in self.cyclades.list_images(detail=True):
-            if image_name in image['name']:
-                return image
-        return None
-
-    def find_project_id(self, **kwargs):
-        """
-        :param kwargs: name, state, owner and mode to filter project by
-        :return: first project_id that matches the project name
-        """
-        filter = {
-            'name':  kwargs.get("project_name"),
-            'state': kwargs.get("project_state"),
-            'owner': kwargs.get("project_owner"),
-            'mode':  kwargs.get("project_mode"),
-        }
-        logger.info("Retrieving project")
-        return self.astakos.get_projects(**filter)[0]
+        self.vms = [self.master, self.slaves]
 
     """
     CREATE RESOURCES
@@ -223,116 +137,6 @@ class Provisioner:
             }
             return inventory
 
-    def create_vm(self, vm_name=None, image_id=None,
-                  ip=None, personality=None, flavor=None, **kwargs):
-        """
-        :param vm_name: Name of the virtual machine to create
-        :param image_id: image id if you want another image than the default
-        :param kwargs: passed to the functions called for detail options
-        :return:
-        """
-        flavor_id = flavor['id']
-        # Get image
-        if image_id == None:
-            image_id = self.image_id
-        else:
-            image_id = self.find_image(**kwargs)['id']
-        project_id = self.find_project_id(**kwargs)['id']
-        networks = list()
-        if ip:
-            ip_obj = dict()
-            ip_obj['uuid'] = ip['floating_network_id']
-            ip_obj['fixed_ip'] = ip['floating_ip_address']
-            networks.append(ip_obj)
-        networks.append({'uuid': kwargs['net_id']})
-        if personality == None:
-            personality = []
-        try:
-            okeanos_response = self.cyclades.create_server(name=vm_name,
-                                                           flavor_id=flavor_id,
-                                                           image_id=image_id,
-                                                           project_id=project_id,
-                                                           networks=networks,
-                                                           personality=personality)
-        except ClientError as ex:
-            raise ex
-        return okeanos_response
-
-    def create_vpn(self, network_name, project_id):
-        """
-        Creates a virtual private network
-        :param network_name: name of the network
-        :return: the virtual network object
-        """
-        try:
-            # Create vpn with custom type and the name given as argument
-            vpn = self.network_client.create_network(
-                type=self.network_client.network_types[1],
-                name=network_name,
-                project_id=project_id)
-            return vpn
-        except ClientError as ex:
-            raise ex
-
-    def reserve_ip(self, project_id):
-        """
-        Reserve ip
-        :return: the ip object if successfull
-        """
-        # list_float_ips = self.network_client.list_floatingips()
-        # for ip in list_float_ips:
-        #     if ip['instance_id'] is None and ip['port_id'] is None and ip not in ips:
-        #         return ip
-        try:
-            ip = self.network_client.create_floatingip(project_id=project_id)
-            return ip
-        except ClientError as ex:
-            raise ex
-
-    def create_private_subnet(self, net_id, cidr='192.168.0.0/24', gateway_ip='192.168.0.1'):
-        """
-        Creates a private subnets and connects it with this network
-        :param net_id: id of the network
-        :return: the id of the subnet if successfull
-        """
-        try:
-            subnet = self.network_client.create_subnet(net_id, cidr,
-                                                       gateway_ip=gateway_ip,
-                                                       enable_dhcp=True)
-            self.subnet = subnet
-            return subnet['id']
-        except ClientError as ex:
-            raise ex
-
-    def connect_vm(self, vm_id, net_id):
-        """
-        Connects the vm with this id to the network with the net_id
-        :param vm_id: id of the vm
-        :param net_id: id of the network
-        :return: returns True if successfull
-        """
-        try:
-            port = self.network_client.create_port(network_id=net_id,
-                                                   device_id=vm_id)
-            return True
-        except ClientError as ex:
-            raise ex
-
-    def attach_authorized_ip(self, ip, vm_id):
-        """
-        Attach the authorized ip with this id to the vm
-        :param fnet_id: id of the floating network of the ip
-        :param vm_id: id of the vm
-        :return: returns True if successfull
-        """
-        try:
-            port = self.network_client.create_port(network_id=ip['floating_network_id'],
-                                                   device_id=vm_id,
-                                                   fixed_ips=[dict(
-                                                       ip_address=ip['floating_ip_address']), ])
-            return True
-        except ClientError as ex:
-            raise ex
 
     """
     DELETE RESOURCES
@@ -362,29 +166,6 @@ class Provisioner:
             msg = 'Error deleting node with id ', node
             raise ClientError(msg, error_fatal)
 
-    def delete_vm(self, vm_id):
-        """
-        Delete a vm
-        :param vm_id: id of the vm we want to delete
-        :return: True if successfull
-        """
-        try:
-            self.cyclades.delete_server(vm_id)
-            return True
-        except ClientError as ex:
-            raise ex
-
-    def delete_vpn(self, net_id):
-        """
-        Delete a virtual private network
-        :param net_id: id of the network we want to delete
-        :return: True if successfull
-        """
-        try:
-            self.network_client.delete_network(net_id)
-            return True
-        except ClientError as ex:
-            raise ex
 
     """
     GET RESOURCES
@@ -434,48 +215,6 @@ class Provisioner:
         subnet['gateway_ip'] = self.subnet['gateway_ip']
         details['subnet'] = subnet
         return details
-
-    def get_private_key(self):
-        """
-        :returns: Private key of master
-        """
-        return self.private_key
-
-    def get_quotas(self, **kwargs):
-        """
-        Get the user quotas for the defined project.
-        :return: user quotas object
-        """
-        return self.astakos.get_quotas()
-
-    def get_server_info(self, server_id):
-        """
-        """
-        return self.cyclades.get_server_details(server_id=server_id)
-
-    def get_server_authorized_ip(self, server_id):
-        """
-        :param server_id: id of the server
-        :returns: the authorized ip of the server if it has one,else None
-        """
-        addresses = self.get_server_info(server_id=server_id)['addresses']
-        for key in list(addresses.keys()):
-            ip = addresses[key][0]['addr']
-            if '192.168.0' not in ip and not re.search('[a-zA-Z]', ip):
-                return ip
-        return None
-
-    def get_server_private_ip(self, server_id):
-        """
-        :param server_id: id of the server
-        :returns: the private ip of the server if it has one,else None
-        """
-        addresses = self.get_server_info(server_id=server_id)['addresses']
-        for key in list(addresses.keys()):
-            ip = addresses[key][0]['addr']
-            if '192.168.0' in ip:
-                return ip
-        return None
 
     """
     CHECK RESOURCES

--- a/core/fokia/provisioner.py
+++ b/core/fokia/provisioner.py
@@ -1,7 +1,6 @@
 from __future__ import (absolute_import, division,
                         print_function, unicode_literals)
 import logging
-import re
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -16,8 +15,8 @@ from base64 import b64encode
 
 from fokia.provisioner_base import ProvisionerBase
 
-
 storage_templates = ['drdb', 'ext_vlmc']
+
 
 class Provisioner(ProvisionerBase):
     """
@@ -25,8 +24,6 @@ class Provisioner(ProvisionerBase):
     """
 
     def __init__(self, auth_token, cloud_name=None):
-
-        #super(C,self).__init__()
         super(Provisioner, self).__init__(auth_token=auth_token, cloud_name=cloud_name)
         self.master = None
         self.slaves = None
@@ -137,7 +134,6 @@ class Provisioner(ProvisionerBase):
             }
             return inventory
 
-
     """
     DELETE RESOURCES
     """
@@ -165,7 +161,6 @@ class Provisioner(ProvisionerBase):
         if (not self.delete_vpn(vpn)):
             msg = 'Error deleting node with id ', node
             raise ClientError(msg, error_fatal)
-
 
     """
     GET RESOURCES

--- a/core/fokia/provisioner_base.py
+++ b/core/fokia/provisioner_base.py
@@ -1,0 +1,326 @@
+from __future__ import (absolute_import, division,
+                        print_function, unicode_literals)
+import logging
+import re
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+from kamaki.clients import astakos, cyclades
+from kamaki.clients import ClientError
+from kamaki.cli.config import Config as KamakiConfig
+from fokia.utils import patch_certs
+from fokia.cluster_error_constants import *
+from Crypto.PublicKey import RSA
+from base64 import b64encode
+
+import abc
+
+storage_templates = ['drdb', 'ext_vlmc']
+
+class ProvisionerBase:
+    """
+        provisions virtual machines on ~okeanos
+    """
+
+    __metaclass__ = abc.ABCMeta
+
+    def __init__(self, auth_token, cloud_name=None):
+        if auth_token is None:
+
+            # Load .kamakirc configuration
+            logger.info("Retrieving .kamakirc configuration")
+            self.config = KamakiConfig()
+            patch_certs(self.config.get('global', 'ca_certs'))
+            if cloud_name is None:
+                cloud_section = self.config._sections['cloud'].get(self.config.get('global', 'default_cloud'))
+            else:
+                cloud_section = self.config._sections['cloud'].get(cloud_name)
+            if not cloud_section:
+                message = "Cloud '%s' was not found in you .kamakirc configuration file. " \
+                          "Currently you have available in your configuration these clouds: %s"
+                raise KeyError(message % (cloud_name, self.config._sections['cloud'].keys()))
+
+            # Get the authentication url and token
+            auth_url, auth_token = cloud_section['url'], cloud_section['token']
+
+        else:
+            auth_url = "https://accounts.okeanos.grnet.gr/identity/v2.0"
+
+        logger.info("Initiating Astakos Client")
+        self.astakos = astakos.AstakosClient(auth_url, auth_token)
+
+        logger.info("Retrieving cyclades endpoint url")
+        compute_url = self.astakos.get_endpoint_url(
+            cyclades.CycladesComputeClient.service_type)
+        logger.info("Initiating Cyclades client")
+        self.cyclades = cyclades.CycladesComputeClient(compute_url, auth_token)
+
+        # Create the network client
+        networkURL = self.astakos.get_endpoint_url(
+            cyclades.CycladesNetworkClient.service_type)
+        self.network_client = cyclades.CycladesNetworkClient(networkURL, auth_token)
+
+        # Constants
+        self.Bytes_to_GB = 1024 * 1024 * 1024
+        self.Bytes_to_MB = 1024 * 1024
+
+        self.vms = []
+        self.ips = None
+        self.vpn = None
+        self.subnet = None
+        self.private_key = None
+        self.image_id = 'c6f5adce-21ad-4ce3-8591-acfe7eb73c02'
+
+    """
+    FIND RESOURCES
+    """
+
+    def find_flavor(self, **kwargs):
+        """
+
+        :param kwargs: should contains the keys that specify the specs
+        :return: first flavor objects that matches the specs criteria
+        """
+
+        # Set all the default parameters
+        kwargs.setdefault("vcpus", 1)
+        kwargs.setdefault("ram", 1024)
+        kwargs.setdefault("disk", 40)
+        kwargs.setdefault("SNF:allow_create", True)
+        logger.info("Retrieving flavor")
+        for flavor in self.cyclades.list_flavors(detail=True):
+            if all([kwargs[key] == flavor[key]
+                    for key in set(flavor.keys()).intersection(kwargs.keys())]):
+                return flavor
+        return None
+
+    def find_image(self, **kwargs):
+        """
+        :param image_name: Name of the image to filter by
+        :param kwargs:
+        :return: first image object that matches the name criteria
+        """
+        image_name = kwargs['image_name']
+
+        logger.info("Retrieving image")
+        for image in self.cyclades.list_images(detail=True):
+            if image_name in image['name']:
+                return image
+        return None
+
+    def find_project_id(self, **kwargs):
+        """
+        :param kwargs: name, state, owner and mode to filter project by
+        :return: first project_id that matches the project name
+        """
+        filter = {
+            'name':  kwargs.get("project_name"),
+            'state': kwargs.get("project_state"),
+            'owner': kwargs.get("project_owner"),
+            'mode':  kwargs.get("project_mode"),
+        }
+        logger.info("Retrieving project")
+        return self.astakos.get_projects(**filter)[0]
+
+    """
+    CREATE RESOURCES
+    """
+
+    def create_vm(self, vm_name=None, image_id=None,
+                  ip=None, personality=None, flavor=None, **kwargs):
+        """
+        :param vm_name: Name of the virtual machine to create
+        :param image_id: image id if you want another image than the default
+        :param kwargs: passed to the functions called for detail options
+        :return:
+        """
+        flavor_id = flavor['id']
+        # Get image
+        if image_id == None:
+            image_id = self.image_id
+        else:
+            image_id = self.find_image(**kwargs)['id']
+        project_id = self.find_project_id(**kwargs)['id']
+        networks = list()
+        if ip:
+            ip_obj = dict()
+            ip_obj['uuid'] = ip['floating_network_id']
+            ip_obj['fixed_ip'] = ip['floating_ip_address']
+            networks.append(ip_obj)
+        networks.append({'uuid': kwargs['net_id']})
+        if personality == None:
+            personality = []
+        try:
+            okeanos_response = self.cyclades.create_server(name=vm_name,
+                                                           flavor_id=flavor_id,
+                                                           image_id=image_id,
+                                                           project_id=project_id,
+                                                           networks=networks,
+                                                           personality=personality)
+        except ClientError as ex:
+            raise ex
+        return okeanos_response
+
+    def create_vpn(self, network_name, project_id):
+        """
+        Creates a virtual private network
+        :param network_name: name of the network
+        :return: the virtual network object
+        """
+        try:
+            # Create vpn with custom type and the name given as argument
+            vpn = self.network_client.create_network(
+                type=self.network_client.network_types[1],
+                name=network_name,
+                project_id=project_id)
+            return vpn
+        except ClientError as ex:
+            raise ex
+
+    def reserve_ip(self, project_id):
+        """
+        Reserve ip
+        :return: the ip object if successfull
+        """
+        # list_float_ips = self.network_client.list_floatingips()
+        # for ip in list_float_ips:
+        #     if ip['instance_id'] is None and ip['port_id'] is None and ip not in ips:
+        #         return ip
+        try:
+            ip = self.network_client.create_floatingip(project_id=project_id)
+            return ip
+        except ClientError as ex:
+            raise ex
+
+    def create_private_subnet(self, net_id, cidr='192.168.0.0/24', gateway_ip='192.168.0.1'):
+        """
+        Creates a private subnets and connects it with this network
+        :param net_id: id of the network
+        :return: the id of the subnet if successfull
+        """
+        try:
+            subnet = self.network_client.create_subnet(net_id, cidr,
+                                                       gateway_ip=gateway_ip,
+                                                       enable_dhcp=True)
+            self.subnet = subnet
+            return subnet['id']
+        except ClientError as ex:
+            raise ex
+
+    def connect_vm(self, vm_id, net_id):
+        """
+        Connects the vm with this id to the network with the net_id
+        :param vm_id: id of the vm
+        :param net_id: id of the network
+        :return: returns True if successfull
+        """
+        try:
+            port = self.network_client.create_port(network_id=net_id,
+                                                   device_id=vm_id)
+            return True
+        except ClientError as ex:
+            raise ex
+
+    def attach_authorized_ip(self, ip, vm_id):
+        """
+        Attach the authorized ip with this id to the vm
+        :param fnet_id: id of the floating network of the ip
+        :param vm_id: id of the vm
+        :return: returns True if successfull
+        """
+        try:
+            port = self.network_client.create_port(network_id=ip['floating_network_id'],
+                                                   device_id=vm_id,
+                                                   fixed_ips=[dict(
+                                                       ip_address=ip['floating_ip_address']), ])
+            return True
+        except ClientError as ex:
+            raise ex
+
+    """
+    DELETE RESOURCES
+    """
+
+    def delete_vm(self, vm_id):
+        """
+        Delete a vm
+        :param vm_id: id of the vm we want to delete
+        :return: True if successfull
+        """
+        try:
+            self.cyclades.delete_server(vm_id)
+            return True
+        except ClientError as ex:
+            raise ex
+
+    def delete_vpn(self, net_id):
+        """
+        Delete a virtual private network
+        :param net_id: id of the network we want to delete
+        :return: True if successfull
+        """
+        try:
+            self.network_client.delete_network(net_id)
+            return True
+        except ClientError as ex:
+            raise ex
+
+    """
+    GET RESOURCES
+    """
+
+    def get_private_key(self):
+        """
+        :returns: Private key of master
+        """
+        return self.private_key
+
+    def get_quotas(self, **kwargs):
+        """
+        Get the user quotas for the defined project.
+        :return: user quotas object
+        """
+        return self.astakos.get_quotas()
+
+    def get_server_info(self, server_id):
+        """
+        """
+        return self.cyclades.get_server_details(server_id=server_id)
+
+    def get_server_authorized_ip(self, server_id):
+        """
+        :param server_id: id of the server
+        :returns: the authorized ip of the server if it has one,else None
+        """
+        addresses = self.get_server_info(server_id=server_id)['addresses']
+        for key in list(addresses.keys()):
+            ip = addresses[key][0]['addr']
+            if '192.168.0' not in ip and not re.search('[a-zA-Z]', ip):
+                return ip
+        return None
+
+    def get_server_private_ip(self, server_id):
+        """
+        :param server_id: id of the server
+        :returns: the private ip of the server if it has one,else None
+        """
+        addresses = self.get_server_info(server_id=server_id)['addresses']
+        for key in list(addresses.keys()):
+            ip = addresses[key][0]['addr']
+            if '192.168.0' in ip:
+                return ip
+        return None
+
+    """
+    CHECK RESOURCES
+    """
+
+    @abc.abstractmethod
+    def check_all_resources(self, quotas, **kwargs):
+        """
+        Checks user's quota for every requested resource.
+        Returns True if everything available.
+        :param **kwargs: arguments
+        """
+        return

--- a/core/fokia/provisioner_base.py
+++ b/core/fokia/provisioner_base.py
@@ -11,12 +11,11 @@ from kamaki.clients import ClientError
 from kamaki.cli.config import Config as KamakiConfig
 from fokia.utils import patch_certs
 from fokia.cluster_error_constants import *
-from Crypto.PublicKey import RSA
-from base64 import b64encode
 
 import abc
 
 storage_templates = ['drdb', 'ext_vlmc']
+
 
 class ProvisionerBase:
     """
@@ -33,7 +32,8 @@ class ProvisionerBase:
             self.config = KamakiConfig()
             patch_certs(self.config.get('global', 'ca_certs'))
             if cloud_name is None:
-                cloud_section = self.config._sections['cloud'].get(self.config.get('global', 'default_cloud'))
+                cloud_section = self.config._sections['cloud'].get(self.config.get('global',
+                                                                                   'default_cloud'))
             else:
                 cloud_section = self.config._sections['cloud'].get(cloud_name)
             if not cloud_section:
@@ -115,10 +115,10 @@ class ProvisionerBase:
         :return: first project_id that matches the project name
         """
         filter = {
-            'name':  kwargs.get("project_name"),
+            'name': kwargs.get("project_name"),
             'state': kwargs.get("project_state"),
             'owner': kwargs.get("project_owner"),
-            'mode':  kwargs.get("project_mode"),
+            'mode': kwargs.get("project_mode"),
         }
         logger.info("Retrieving project")
         return self.astakos.get_projects(**filter)[0]
@@ -137,7 +137,7 @@ class ProvisionerBase:
         """
         flavor_id = flavor['id']
         # Get image
-        if image_id == None:
+        if image_id is None:
             image_id = self.image_id
         else:
             image_id = self.find_image(**kwargs)['id']
@@ -149,7 +149,7 @@ class ProvisionerBase:
             ip_obj['fixed_ip'] = ip['floating_ip_address']
             networks.append(ip_obj)
         networks.append({'uuid': kwargs['net_id']})
-        if personality == None:
+        if personality is None:
             personality = []
         try:
             okeanos_response = self.cyclades.create_server(name=vm_name,
@@ -216,8 +216,8 @@ class ProvisionerBase:
         :return: returns True if successfull
         """
         try:
-            port = self.network_client.create_port(network_id=net_id,
-                                                   device_id=vm_id)
+            self.network_client.create_port(network_id=net_id,
+                                            device_id=vm_id)
             return True
         except ClientError as ex:
             raise ex
@@ -230,10 +230,10 @@ class ProvisionerBase:
         :return: returns True if successfull
         """
         try:
-            port = self.network_client.create_port(network_id=ip['floating_network_id'],
-                                                   device_id=vm_id,
-                                                   fixed_ips=[dict(
-                                                       ip_address=ip['floating_ip_address']), ])
+            self.network_client.create_port(network_id=ip['floating_network_id'],
+                                            device_id=vm_id,
+                                            fixed_ips=[dict(
+                                                ip_address=ip['floating_ip_address']), ])
             return True
         except ClientError as ex:
             raise ex

--- a/core/tests/test_provisioner.py
+++ b/core/tests/test_provisioner.py
@@ -199,9 +199,9 @@ test_vm = {u'addresses': {}, u'links': [
 
 
 def test_find_flavor():
-    with mock.patch('fokia.provisioner.astakos'), \
-            mock.patch('fokia.provisioner.KamakiConfig'), \
-            mock.patch('fokia.provisioner.cyclades'):
+    with mock.patch('fokia.provisioner_base.astakos'), \
+            mock.patch('fokia.provisioner_base.KamakiConfig'), \
+            mock.patch('fokia.provisioner_base.cyclades'):
         provisioner = Provisioner(None, "lambda")
         provisioner.astakos.get_projects.return_value = test_projects
         provisioner.cyclades.list_images.return_value = test_images
@@ -220,9 +220,9 @@ def test_find_flavor():
 
 
 def test_check_all_resources():
-    with mock.patch('fokia.provisioner.astakos'), \
-            mock.patch('fokia.provisioner.KamakiConfig'), \
-            mock.patch('fokia.provisioner.cyclades'):
+    with mock.patch('fokia.provisioner_base.astakos'), \
+            mock.patch('fokia.provisioner_base.KamakiConfig'), \
+            mock.patch('fokia.provisioner_base.cyclades'):
         provisioner = Provisioner(None, "lambda")
         provisioner.astakos.get_projects.return_value = test_projects
         provisioner.astakos.get_quotas.return_value = test_quotas
@@ -238,26 +238,26 @@ def test_check_all_resources():
 
 
 def test_create_vpn():
-    with mock.patch('fokia.provisioner.astakos'), \
-            mock.patch('fokia.provisioner.KamakiConfig'), \
-            mock.patch('fokia.provisioner.cyclades'):
+    with mock.patch('fokia.provisioner_base.astakos'), \
+            mock.patch('fokia.provisioner_base.KamakiConfig'), \
+            mock.patch('fokia.provisioner_base.cyclades'):
         provisioner = Provisioner(None, "lambda")
         provisioner.network_client.create_network = test_ip
         provisioner.reserve_ip('6ff62e8e-0ce9-41f7-ad99-13a18ecada5f')
 
 
 def test_create_vm():
-    with mock.patch('fokia.provisioner.astakos'), \
-            mock.patch('fokia.provisioner.KamakiConfig'), \
-            mock.patch('fokia.provisioner.cyclades'):
+    with mock.patch('fokia.provisioner_base.astakos'), \
+            mock.patch('fokia.provisioner_base.KamakiConfig'), \
+            mock.patch('fokia.provisioner_base.cyclades'):
         provisioner = Provisioner(None, "lambda")
         provisioner.cyclades.create_server = test_vm
 
 
 def test_connect_vm():
-    with mock.patch('fokia.provisioner.astakos'), \
-            mock.patch('fokia.provisioner.KamakiConfig'), \
-            mock.patch('fokia.provisioner.cyclades'):
+    with mock.patch('fokia.provisioner_base.astakos'), \
+            mock.patch('fokia.provisioner_base.KamakiConfig'), \
+            mock.patch('fokia.provisioner_base.cyclades'):
         provisioner = Provisioner(None, "lambda")
         provisioner.network_client.create_port = True
 

--- a/core/tox.ini
+++ b/core/tox.ini
@@ -24,5 +24,5 @@ commands=
 
 [flake8]
 max-line-length = 100
-ignore = E127,E241
+ignore = E127,F403,E241
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
 [flake8]
 max-line-length = 100
-ignore = E127,E241
+ignore = E127,F403,E241
 


### PR DESCRIPTION
## Description

Divided Provisioner functionality into two classes, `ProvisionerBase` and `Provisioner`.
- **ProvisionerBase** is responsible for spawning/managing VMs in general.
- **Provisioner** is more specific to the Lambda cluster, so it can refer to master and slaves.

Last, I had to make some change to tox test in **test_provisioner.py** in order to refer to the base class for the mock objects.
## Goal of the changes

The aim is to incorporate functionality of ProvisionerBase into another class, responsible for creating the Central ~okeanos LoD service (LAM-132). With the current change, we maximize code reuse.
