### PR TITLE
Minor fixes

### DIFF
--- a/webapp/backend/exceptions.py
+++ b/webapp/backend/exceptions.py
@@ -70,12 +70,21 @@ custom_exceptions = (CustomAuthenticationFailed, CustomParseError, CustomValidat
                      CustomNotFoundError, CustomAlreadyDoneError, CustomCantDoError)
 
 
-def parse_custom_exception(default_response):
+def parse_custom_exception(exception, default_response):
     response = dict({'errors': []})
 
-    for key, value in default_response.data.items():
-        response['errors'].append({'status': default_response.status_code,
-                                   'detail': value})
+    if isinstance(exception, CustomValidationError):
+        for key, values in default_response.data.items():
+            detail = []
+            for value in values:
+                detail.append("{key}: {value}".format(key=key, value=value))
+
+            response['errors'].append({'status': default_response.status_code,
+                                       'detail': detail})
+    else:
+        for key, value in default_response.data.items():
+            response['errors'].append({'status': default_response.status_code,
+                                       'detail': value})
 
     response_status = default_response.status_code
     return Response(response, response_status)
@@ -86,6 +95,6 @@ def custom_exception_handler(exc, context):
     default_response = exception_handler(exc, context)
 
     if isinstance(exc, custom_exceptions):
-        return parse_custom_exception(default_response)
+        return parse_custom_exception(exc, default_response)
 
     return default_response

--- a/webapp/backend/exceptions.py
+++ b/webapp/backend/exceptions.py
@@ -20,20 +20,17 @@ class CustomParseError(APIException):
 
     messages = {
         'no_file_error': "No file uploaded.",
-        'no_lambda_instance_id_error': "No lambda instance id provided."
+        'no_lambda_instance_id_error': "No lambda instance id provided.",
+        'limit_value_error': "limit value should be an integer greater or equal to zero.",
+        'filename_already_exists_error': "The specified file name already exists.",
+        'filter_value_error': "filter GET parameter can be used with values status or info.",
+        'action_value_error': "action POST parameter can be used with start or stop value."
     }
 
 
 class CustomValidationError(ValidationError):
     status_code = status.HTTP_400_BAD_REQUEST
     default_detail = "Validation Error."
-
-    messages = {
-        'limit_value_error': "limit value should be an integer greater or equal to zero.",
-        'filename_already_exists_error': "The specified file name already exists.",
-        'filter_value_error': "filter GET parameter can be used with values status or info.",
-        'action_value_error': "action POST parameter can be used with start or stop value."
-    }
 
 
 class CustomNotFoundError(APIException):

--- a/webapp/backend/views.py
+++ b/webapp/backend/views.py
@@ -47,9 +47,9 @@ def _paginate_response(view, request, default_response):
             if limit >= 0:
                 default_response = _parse_default_pagination_response(default_response)
             else:
-                raise CustomValidationError(CustomValidationError.messages['limit_value_error'])
+                raise CustomParseError(CustomParseError.messages['limit_value_error'])
         except ValueError:
-            raise CustomValidationError(CustomValidationError.messages['limit_value_error'])
+            raise CustomParseError(CustomParseError.messages['limit_value_error'])
     else:
         # Add 'data' as the root element.
         default_response.data = {"data": default_response.data}
@@ -177,7 +177,7 @@ class ApplicationViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
 
         # Check if another file with same name already exists.
         if self.get_queryset().filter(name=uploaded_file.name).count() > 0:
-            raise CustomValidationError(CustomValidationError
+            raise CustomParseError(CustomParseError
                                         .messages['filename_already_exists_error'])
 
         # Get the description provided with the request.
@@ -479,7 +479,7 @@ class LambdaInstanceViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
         elif filter == "":
             wanted_fields = ['uuid', 'name', 'instance_info', 'status', 'failure_message']
         else:
-            raise CustomValidationError(CustomValidationError.messages['filter_value_error'])
+            raise CustomParseError(CustomParseError.messages['filter_value_error'])
 
         unwanted_fields = set(LambdaInstanceSerializer.Meta.fields) - set(wanted_fields)
 
@@ -600,7 +600,7 @@ class LambdaInstanceViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
                                                status=LambdaInstance.status_choices[
                                                    int(lambda_instance_data['status'])][1]))
         else:
-            raise CustomValidationError(CustomValidationError.messages['action_value_error'])
+            raise CustomParseError(CustomParseError.messages['action_value_error'])
 
         # Get the id of the master node and the ids of the slave nodes.
         master_id = None

--- a/webapp/backend/views.py
+++ b/webapp/backend/views.py
@@ -657,9 +657,7 @@ class LambdaInstanceViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
                                              .messages['lambda_instance_already']
                                              .format(state="destroyed"))
 
-        if lambda_instance_data['status'] != LambdaInstance.STARTED and \
-            lambda_instance_data['status'] != LambdaInstance.STOPPED and \
-                lambda_instance_data['status'] != LambdaInstance.FAILED:
+        if lambda_instance_data['status'] == LambdaInstance.CLUSTER_FAILED:
             raise CustomCantDoError(CustomCantDoError.messages['cant_do'].
                                         format(action="destroy", object="a lambda instance",
                                                status=LambdaInstance.status_choices[


### PR DESCRIPTION
# Fixes
1. When the user sends a DELETE request for an application, the application is deleted from the database even if the file is not found on Pithos. This is done to avoid the following scenario:
   - The user uploads a file but, due to some error, the file doesn't get uploaded to Pithos. In this case, the database entry of the application will exist and the user will not be able to delete it since an error message `Application doesn't exist` will be returned on each attempt.
2. Moved all messages from CustomValidationError to CustomParseError. This is done because CustomValidationError needs a special input format and not just plain text. CustomValidationError will only be used for errors raised from Django Rest Framework's validators.
3. Fixed validator's response when missing a required field. The old message was `This field is required.` without specifying the name of the field. The new message is `[field-name]: This field is required.`.
4. Made deletion of a lambda-instance possible even if it is in failed state. This is done to avoid the following scenario:
   - A user creates a lambda-instance but it fails at init|common|hadoop|kafka|flink installation. In this case, since the resources on ~okeanos are already taken, the user should be able to release them through the API.
