### PR TITLE
[LAM-148] Rework provisioner ssl cert path detection

### DIFF
--- a/core/fokia/provisioner_base.py
+++ b/core/fokia/provisioner_base.py
@@ -25,12 +25,13 @@ class ProvisionerBase:
     __metaclass__ = abc.ABCMeta
 
     def __init__(self, auth_token, cloud_name=None):
-        if auth_token is None:
 
+        if auth_token is None:
             # Load .kamakirc configuration
             logger.info("Retrieving .kamakirc configuration")
             self.config = KamakiConfig()
-            patch_certs(self.config.get('global', 'ca_certs'))
+            if not os.path.exists(self.config.path):
+                raise IOError('No auth token given, and .kamakirc does not exist! Aborting.')
             if cloud_name is None:
                 cloud_section = self.config._sections['cloud'].get(self.config.get('global',
                                                                                    'default_cloud'))
@@ -46,6 +47,8 @@ class ProvisionerBase:
 
         else:
             auth_url = "https://accounts.okeanos.grnet.gr/identity/v2.0"
+
+        patch_certs()
 
         logger.info("Initiating Astakos Client")
         self.astakos = astakos.AstakosClient(auth_url, auth_token)

--- a/core/fokia/utils.py
+++ b/core/fokia/utils.py
@@ -20,8 +20,11 @@ def patch_certs():
     """
 
     if not defaults.CACERTS_DEFAULT_PATH:
-        config = KamakiConfig()
-        cert_path = config.get('global', 'ca_certs')
+        try:
+            config = KamakiConfig()
+            cert_path = config.get('global', 'ca_certs')
+        except:
+            cert_path = None
         if cert_path:
             https.patch_with_certs(cert_path)
         else:

--- a/core/fokia/utils.py
+++ b/core/fokia/utils.py
@@ -12,6 +12,8 @@ from kamaki.clients.astakos import AstakosClient
 from kamaki.clients.cyclades import CycladesComputeClient
 from kamaki.cli.config import Config as KamakiConfig
 
+try_paths = ['/etc/ssl/certs/ca-certificates.crt', '/usr/local/etc/openssl/cert.pem']
+
 
 def patch_certs():
     """
@@ -19,30 +21,37 @@ def patch_certs():
     :param cert_path: Path to the certificate file
     """
 
-    if not defaults.CACERTS_DEFAULT_PATH:
-        try:
-            config = KamakiConfig()
-            cert_path = config.get('global', 'ca_certs')
-        except:
-            cert_path = None
-        if cert_path and os.path.exists(cert_path):
-            https.patch_with_certs(cert_path)
-        else:
-            try:
-                from ssl import get_default_verify_paths
-                cert_path = get_default_verify_paths().cafile or \
-                    get_default_verify_paths().openssl_cafile
-            except:
-                pass
-            try_path = '/etc/ssl/certs/ca-certificates.crt'
-            if cert_path and os.path.exists(cert_path):
-                https.patch_with_certs(cert_path)
-            elif os.path.exists(try_path):
-                https.patch_with_certs(try_path)
-            else:
-                logger.warn("COULD NOT FIND ANY CERTIFICATES, PLEASE SET THEM IN YOUR "
-                            ".kamakirc 'global' SECTION, OPTION 'ca_certs'")
-                https.patch_ignore_ssl()
+    if defaults.CACERTS_DEFAULT_PATH and os.path.exists(defaults.CACERTS_DEFAULT_PATH):
+        return
+
+    try:
+        config = KamakiConfig()
+        cert_path = config.get('global', 'ca_certs')
+    except:
+        cert_path = None
+    if cert_path and os.path.exists(cert_path):
+        https.patch_with_certs(cert_path)
+        return
+
+    try:
+        from ssl import get_default_verify_paths
+        cert_path = get_default_verify_paths().cafile or \
+            get_default_verify_paths().openssl_cafile
+    except:
+        pass
+    if cert_path and os.path.exists(cert_path):
+        https.patch_with_certs(cert_path)
+        return
+
+    for path in try_paths:
+        if os.path.exists(path):
+            https.patch_with_certs(path)
+            return
+
+    logger.warn("COULD NOT FIND ANY CERTIFICATES, PLEASE SET THEM IN YOUR "
+                ".kamakirc 'global' SECTION, OPTION 'ca_certs'")
+    https.patch_ignore_ssl()
+    return
 
 
 def check_auth_token(auth_token, auth_url=None):

--- a/core/fokia/utils.py
+++ b/core/fokia/utils.py
@@ -10,15 +10,18 @@ from kamaki import defaults
 from kamaki.clients.pithos import PithosClient
 from kamaki.clients.astakos import AstakosClient
 from kamaki.clients.cyclades import CycladesComputeClient
+from kamaki.cli.config import Config as KamakiConfig
 
 
-def patch_certs(cert_path=None):
+def patch_certs():
     """
     Patch http certificates or ignore_ssl() if no certificates ca be found
     :param cert_path: Path to the certificate file
     """
 
     if not defaults.CACERTS_DEFAULT_PATH:
+        config = KamakiConfig()
+        cert_path = config.get('global', 'ca_certs')
         if cert_path:
             https.patch_with_certs(cert_path)
         else:
@@ -28,12 +31,14 @@ def patch_certs(cert_path=None):
                     get_default_verify_paths().openssl_cafile
             except:
                 pass
-
+            try_path = '/etc/ssl/certs/ca-certificates.crt'
             if cert_path:
                 https.patch_with_certs(cert_path)
+            elif os.path.exists(try_path):
+                https.patch_with_certs(try_path)
             else:
                 logger.warn("COULD NOT FIND ANY CERTIFICATES, PLEASE SET THEM IN YOUR "
-                            ".kamakirc global section, option ca_certs")
+                            ".kamakirc 'global' SECTION, OPTION 'ca_certs'")
                 https.patch_ignore_ssl()
 
 

--- a/core/fokia/utils.py
+++ b/core/fokia/utils.py
@@ -25,7 +25,7 @@ def patch_certs():
             cert_path = config.get('global', 'ca_certs')
         except:
             cert_path = None
-        if cert_path:
+        if cert_path and os.path.exists(cert_path):
             https.patch_with_certs(cert_path)
         else:
             try:
@@ -35,7 +35,7 @@ def patch_certs():
             except:
                 pass
             try_path = '/etc/ssl/certs/ca-certificates.crt'
-            if cert_path:
+            if cert_path and os.path.exists(cert_path):
                 https.patch_with_certs(cert_path)
             elif os.path.exists(try_path):
                 https.patch_with_certs(try_path)

--- a/core/tests/test_provisioner.py
+++ b/core/tests/test_provisioner.py
@@ -201,7 +201,9 @@ test_vm = {u'addresses': {}, u'links': [
 def test_find_flavor():
     with mock.patch('fokia.provisioner_base.astakos'), \
             mock.patch('fokia.provisioner_base.KamakiConfig'), \
-            mock.patch('fokia.provisioner_base.cyclades'):
+            mock.patch('fokia.provisioner_base.cyclades'), \
+            mock.patch('fokia.provisioner_base.os.path.exists') as mock_exists:
+        mock_exists.return_value = True
         provisioner = Provisioner(None, "lambda")
         provisioner.astakos.get_projects.return_value = test_projects
         provisioner.cyclades.list_images.return_value = test_images
@@ -222,7 +224,9 @@ def test_find_flavor():
 def test_check_all_resources():
     with mock.patch('fokia.provisioner_base.astakos'), \
             mock.patch('fokia.provisioner_base.KamakiConfig'), \
-            mock.patch('fokia.provisioner_base.cyclades'):
+            mock.patch('fokia.provisioner_base.cyclades'),\
+            mock.patch('fokia.provisioner_base.os.path.exists') as mock_exists:
+        mock_exists.return_value = True
         provisioner = Provisioner(None, "lambda")
         provisioner.astakos.get_projects.return_value = test_projects
         provisioner.astakos.get_quotas.return_value = test_quotas
@@ -240,7 +244,9 @@ def test_check_all_resources():
 def test_create_vpn():
     with mock.patch('fokia.provisioner_base.astakos'), \
             mock.patch('fokia.provisioner_base.KamakiConfig'), \
-            mock.patch('fokia.provisioner_base.cyclades'):
+            mock.patch('fokia.provisioner_base.cyclades'), \
+            mock.patch('fokia.provisioner_base.os.path.exists') as mock_exists:
+        mock_exists.return_value = True
         provisioner = Provisioner(None, "lambda")
         provisioner.network_client.create_network = test_ip
         provisioner.reserve_ip('6ff62e8e-0ce9-41f7-ad99-13a18ecada5f')
@@ -249,7 +255,9 @@ def test_create_vpn():
 def test_create_vm():
     with mock.patch('fokia.provisioner_base.astakos'), \
             mock.patch('fokia.provisioner_base.KamakiConfig'), \
-            mock.patch('fokia.provisioner_base.cyclades'):
+            mock.patch('fokia.provisioner_base.cyclades'),\
+            mock.patch('fokia.provisioner_base.os.path.exists') as mock_exists:
+        mock_exists.return_value = True
         provisioner = Provisioner(None, "lambda")
         provisioner.cyclades.create_server = test_vm
 
@@ -257,7 +265,9 @@ def test_create_vm():
 def test_connect_vm():
     with mock.patch('fokia.provisioner_base.astakos'), \
             mock.patch('fokia.provisioner_base.KamakiConfig'), \
-            mock.patch('fokia.provisioner_base.cyclades'):
+            mock.patch('fokia.provisioner_base.cyclades'),\
+            mock.patch('fokia.provisioner_base.os.path.exists') as mock_exists:
+        mock_exists.return_value = True
         provisioner = Provisioner(None, "lambda")
         provisioner.network_client.create_port = True
 


### PR DESCRIPTION
- Changes in the way ssl cert path is detected:
  - The patch_certs utils function is called every time, even when an auth token is given as argument
  - One more path is added, for searching for ca certificates. Reason for this is that when installing kamaki through pip, the defaults.CACERTS_DEFAULT_PATH property is not set
- When no auth token is given as argument to the provisioner, and no .kamakirc file exists, raise exception
