### PR TITLE
LAM-159 Not passing vm_name in VM managers causes Internal Server Error on kamaki

### DIFF
--- a/central_service/manager/central_service_manager.py
+++ b/central_service/manager/central_service_manager.py
@@ -88,7 +88,8 @@ if __name__ == "__main__":
                         choices=['create', 'start', 'stop', 'destroy'])
     parser.add_argument('--auth_token', type=str, dest='auth_token', required=False)
     parser.add_argument('--vm_id', type=int, dest='vm_id')
-    parser.add_argument('--vm_name', type=str, dest='vm_name', required=False)
+    parser.add_argument('--vm_name', type=str, dest='vm_name', required=False,
+                        default='Central Service')
     parser.add_argument('--vcpus', type=int, dest='vcpus', default='4',
                         choices=[1, 2, 4, 8])
     parser.add_argument('--ram', type=int, dest='ram', default='4096',

--- a/webapp/manager/service_vm_manager.py
+++ b/webapp/manager/service_vm_manager.py
@@ -125,7 +125,8 @@ if __name__ == "__main__":
                         choices=['create', 'start', 'stop', 'destroy'])
     parser.add_argument('--auth_token', type=str, dest='auth_token', required=False)
     parser.add_argument('--vm_id', type=int, dest='vm_id')
-    parser.add_argument('--vm_name', type=str, dest='vm_name', required=False)
+    parser.add_argument('--vm_name', type=str, dest='vm_name', required=False,
+                        default="Service VM")
     parser.add_argument('--vcpus', type=int, dest='vcpus', default='4',
                         choices=[1, 2, 4, 8])
     parser.add_argument('--ram', type=int, dest='ram', default='4096',


### PR DESCRIPTION
## Description

When `--vm_name` is not specified though the command line, there is no default argument in argument parsing and and `None` is passed to the relevant method creating the vm shadowing this way the default method argument.
As a result of this, kamaki throws `Internal Server Error` and the vm is not created.
## Solution

Added default value if the `vm_name` parameter is not specified through the cli.
