### PR TITLE
Additional information in Lambda Instances List API call

### DIFF
--- a/webapp/api-doc/docs/LambdaInstancesList.md
+++ b/webapp/api-doc/docs/LambdaInstancesList.md
@@ -50,6 +50,10 @@ status | The status code of the response | None
 next | The URL to be used to list the next lambda instance | null
 previous | The URL to be used to list the previous lambda instance | null
 count | The number of existing lambda instances | None
+code | A code defining the state of the lambda instance| 2
+message | A literal explaining the code| PENDING
+detail | Some details for the message | Lambda instance installation is pending.
+failure_message | An optional message in case something went wrong| None
 
 ## Example
 
@@ -76,23 +80,49 @@ If the authentication token is correct, a sample response is
   "data": [
     {
       "name": "My first Lambda Instance",
-      "id": "9ac8e7ab-57f9-48a6-af18-ef8a749b1e8c"
+      "id": "9ac8e7ab-57f9-48a6-af18-ef8a749b1e8c",
+      "status": {
+        "message": "STARTED",
+        "code": "0",
+        "detail": "Lambda instance has been started."
+      }
     },
     {
       "name": "Lambda Instance 1",
-      "id": "bc206a2a-b220-43e5-9d76-a7774de5c377"
+      "id": "bc206a2a-b220-43e5-9d76-a7774de5c377",
+      "status": {
+        "message": "STARTED",
+        "code": "0",
+        "detail": "Lambda instance has been started."
+      }
     },
     {
       "name": "Lambda Instance 2",
-      "id": "b141f48c-787b-4345-af6d-1e2e84a45c7e"
+      "id": "b141f48c-787b-4345-af6d-1e2e84a45c7e",
+      "status": {
+        "message": "STARTED",
+        "code": "0",
+        "detail": "Lambda instance has been started."
+      }
     },
     {
       "name": "Lambda Instance 3",
-      "id": "8d8b574b-742e-4b90-9926-3c034dc40516"
+      "id": "8d8b574b-742e-4b90-9926-3c034dc40516",
+      "status": {
+        "message": "STARTED",
+        "code": "0",
+        "detail": "Lambda instance has been started."
+      }
     },
     {
       "name": "Lambda Instance 4",
-      "id": "bbe29514-4f21-4960-89b3-becd82515ef3"
+      "id": "bbe29514-4f21-4960-89b3-becd82515ef3",
+      "status": {
+        "message": "KAFKA_FAILED",
+        "code": "17",
+        "detail": "Apache Kafka installation and configuration have failed."
+        "failure_message": "Ansible task failed"
+      }
     }
   ]
 }
@@ -117,9 +147,25 @@ If the authentication token is correct, a sample response is
     "next":null,
     "previous":"http://<hostname>/api/lambda-instances/?limit=2&offset=1",
   },
-  "data":[
-    {"name":"Lambda Instance 3","id":"8d8b574b-742e-4b90-9926-3c034dc40516"},
-    {"name":"Lambda Instance 4","id":"bbe29514-4f21-4960-89b3-becd82515ef3"}
+  "data":[{
+      "name":"Lambda Instance 3",
+      "id":"8d8b574b-742e-4b90-9926-3c034dc40516",
+      "status": {
+        "message": "STARTED",
+        "code": "0",
+        "detail": "Lambda instance has been started."
+      }
+    },
+    {
+      "name":"Lambda Instance 4",
+      "id":"bbe29514-4f21-4960-89b3-becd82515ef3",
+      "status": {
+        "message": "KAFKA_FAILED",
+        "code": "17",
+        "detail": "Apache Kafka installation and configuration have failed."
+        "failure_message": "Ansible task failed"
+      }
+    }
   ],
   "status": {
     "short_description": "Lambda instances.",

--- a/webapp/backend/views.py
+++ b/webapp/backend/views.py
@@ -878,7 +878,7 @@ class LambdaInstanceViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
         but are not wanted in a list response
         """
 
-        wanted_fields = ['uuid', 'name']
+        wanted_fields = ['uuid', 'name', 'status', 'failure_message']
         unwanted_fields = set(LambdaInstanceSerializer.Meta.fields) - set(wanted_fields)
 
         for lambda_instance in response['data']:
@@ -887,6 +887,17 @@ class LambdaInstanceViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
 
         response['status']['short_description'] = ResponseMessages.short_descriptions[
             'lambda_instances_list']
+
+        for lambda_instance in response['data']:
+            lambda_instance['status'] = {
+                'code': lambda_instance['status'],
+                'message': LambdaInstance.status_choices[int(lambda_instance['status'])][1],
+                'detail': ResponseMessages.lambda_instance_status_details[
+                    LambdaInstance.status_choices[int(lambda_instance['status'])][1]]
+            }
+            if lambda_instance['failure_message'] != "":
+                lambda_instance['status']['failure_message'] = lambda_instance['failure_message']
+            del lambda_instance['failure_message']
 
         # Change uuid name to id
         for item in response['data']:

--- a/webapp/tests/test_lambda_instances.py
+++ b/webapp/tests/test_lambda_instances.py
@@ -364,6 +364,11 @@ class TestLambdaInstancesList(APITestCase):
         for lambda_instance in response.data['data']:
             self.assertIn('id', lambda_instance)
             self.assertIn('name', lambda_instance)
+            self.assertIn('status', lambda_instance)
+
+            self.assertIn('code', lambda_instance['status'])
+            self.assertIn('message', lambda_instance['status'])
+            self.assertIn('detail', lambda_instance['status'])
 
     def _assert_success_request_response_content(self, response, offset=0):
         # Assert the contents of the response.
@@ -371,7 +376,7 @@ class TestLambdaInstancesList(APITestCase):
         self.assertEqual(response.data['status']['short_description'],
                          ResponseMessages.short_descriptions['lambda_instances_list'])
 
-        # Gather all the returned lambda instance names and asser the id of each lambda instance.
+        # Gather all the returned lambda instance names and assert the id of each lambda instance.
         returned_lambda_instance_names = list()
         for lambda_instance in response.data['data']:
             returned_lambda_instance_names.append(lambda_instance['name'])
@@ -386,6 +391,16 @@ class TestLambdaInstancesList(APITestCase):
         # instance names and that the sizes of these sets are equal.
         for expected_lambda_instance_name in expected_lambda_instance_names:
             self.assertIn(expected_lambda_instance_name, returned_lambda_instance_names)
+
+        # Assert that the message, the code and the detail inside lambda instance status are
+        # correctly chosen.
+        for lambda_instance in response.data['data']:
+            self.assertEqual(lambda_instance['status']['message'],
+                             LambdaInstance.status_choices[
+                                 int(lambda_instance['status']['code'])][1])
+            self.assertEqual(lambda_instance['status']['detail'],
+                             ResponseMessages.lambda_instance_status_details[
+                                 lambda_instance['status']['message']])
 
         self.assertEqual(len(expected_lambda_instance_names), len(returned_lambda_instance_names))
 


### PR DESCRIPTION
# Description

Added failure message and status information in Lambda Instances List API call on the Service VM.
# Reason

This information is required by the front end, list lambda instance page.
