### PR TITLE
Generic webapp adapter and serializer

### DIFF
--- a/webapp/frontend/app/adapters/application.js
+++ b/webapp/frontend/app/adapters/application.js
@@ -1,7 +1,11 @@
 import DS from "ember-data";
+import ENV from 'frontend/config/environment';
 
-var ApplicationAdapter = DS.Adapter.extend({
-  host: 'http://localhost:80'
+export default DS.JSONAPIAdapter.extend({
+  host: ENV.host + ':80',
+  namespace: 'api',
+  headers: {
+    'Authorization': "Token " + "12345678",
+    'Accept': "application/json"
+  }
 });
-
-export default ApplicationAdapter;

--- a/webapp/frontend/app/serializers/application.js
+++ b/webapp/frontend/app/serializers/application.js
@@ -1,32 +1,24 @@
+import Ember from "ember";
 import DS from 'ember-data';
 
 export default DS.JSONAPISerializer.extend({
 
-  keyForAttribute: function(attr) {
+  keyForAttribute: function (attr) {
     return Ember.String.underscore(attr);
   },
 
-  extractAttributes: function(modelClass, resourceHash) {
-    var attributeKey;
-    var attributes = {};
-    console.debug(resourceHash);
-
-    modelClass.eachAttribute((key) => {
-      attributeKey = this.keyForAttribute(key, 'deserialize');
-      if (resourceHash.hasOwnProperty(attributeKey)) {
-        attributes[key] = resourceHash[attributeKey];
-      }
-    });
-    console.debug(attributes);
-    return attributes;
+  normalizeResponse: function (store, primaryModelClass, payload, id, requestType) {
+    for (var i = 0; i < payload.data.length; i++) {
+      payload.data[i].attributes = Ember.$.extend(true, {}, payload.data[i]);
+      payload.data[i].type = primaryModelClass.modelName;
+    }
+    delete payload.status;
+    return this._super(store, primaryModelClass, payload, id, requestType);
   },
 
-  _extractType: function(modelClass, resourceHash) {
-    console.debug(modelClass.modelName);
-    return modelClass.modelName;
-  },
-
-  normalizeSingleResponse: function(store, primaryModelClass, payload, id, requestType) {
-    return this._normalizeResponse(store, primaryModelClass, payload, id, requestType, false);
+  normalizeSingleResponse: function (store, primaryModelClass, payload, id, requestType) {
+    payload.data = payload.data[0];
+    return this._super(store, primaryModelClass, payload, id, requestType);
   }
+
 });

--- a/webapp/frontend/app/serializers/application.js
+++ b/webapp/frontend/app/serializers/application.js
@@ -1,0 +1,32 @@
+import DS from 'ember-data';
+
+export default DS.JSONAPISerializer.extend({
+
+  keyForAttribute: function(attr) {
+    return Ember.String.underscore(attr);
+  },
+
+  extractAttributes: function(modelClass, resourceHash) {
+    var attributeKey;
+    var attributes = {};
+    console.debug(resourceHash);
+
+    modelClass.eachAttribute((key) => {
+      attributeKey = this.keyForAttribute(key, 'deserialize');
+      if (resourceHash.hasOwnProperty(attributeKey)) {
+        attributes[key] = resourceHash[attributeKey];
+      }
+    });
+    console.debug(attributes);
+    return attributes;
+  },
+
+  _extractType: function(modelClass, resourceHash) {
+    console.debug(modelClass.modelName);
+    return modelClass.modelName;
+  },
+
+  normalizeSingleResponse: function(store, primaryModelClass, payload, id, requestType) {
+    return this._normalizeResponse(store, primaryModelClass, payload, id, requestType, false);
+  }
+});


### PR DESCRIPTION
This is the first implementation of generic webapp adapter and serializer.
The serializer serializes the responses from the lambda API. For specific API calls, one needs to extend the corresponding normalizeSingleResponse or normalizeArrayResponse methods of the application serializer, as in #115.
