### PR TITLE
Fix for change on success of lambda instance (0 instead of 20)

### DIFF
--- a/central_service/ansible/roles/central-vm/templates/settings.py.j2
+++ b/central_service/ansible/roles/central-vm/templates/settings.py.j2
@@ -44,8 +44,8 @@ INSTALLED_APPS = (
 
 REST_FRAMEWORK = {
     'DEFAULT_RENDERER_CLASSES': (
-        'rest_framework_xml.renderers.XMLRenderer',
         'rest_framework.renderers.JSONRenderer',
+        'rest_framework_xml.renderers.XMLRenderer',
         'rest_framework.renderers.BrowsableAPIRenderer',
     ),
     'EXCEPTION_HANDLER': 'backend.exceptions.custom_exception_handler',

--- a/central_service/app/backend/tests/test_lambda_instances.py
+++ b/central_service/app/backend/tests/test_lambda_instances.py
@@ -30,7 +30,7 @@ class TestLambdaInstances(APITestCase):
             'uuid': '24b8a635-8d71-4016-b8f5-c4a14348ed1f',
             'name': 'test_lambda_instance',
             'instance_info': 'test_content',
-            'status': '20',
+            'status': '0',
             'failure_message': 'OK',
         }
 
@@ -524,7 +524,7 @@ class TestLambdaInstances(APITestCase):
                          response.data['status']['short_description'])
 
         number_of_lambda_instances = \
-            LambdaInstance.objects.filter(status="20").count()
+            LambdaInstance.objects.filter(status="0").count()
 
         self.assertEqual(str(number_of_lambda_instances), response.data['data']['count'])
 
@@ -551,6 +551,6 @@ class TestLambdaInstances(APITestCase):
                          response.data['status']['short_description'])
 
         number_of_lambda_instances = \
-            LambdaInstance.objects.filter(status="20").count()
+            LambdaInstance.objects.filter(status="0").count()
 
         self.assertEqual(str(number_of_lambda_instances), response.data['data']['count'])

--- a/central_service/app/backend/views.py
+++ b/central_service/app/backend/views.py
@@ -303,7 +303,7 @@ class LambdaInstanceCounterView(APIView):
 
     # GET /api/lambda_instances/count
     def get(self, request, format=None):
-        activeLambdaInstances = LambdaInstance.objects.filter(status="20").count()
+        activeLambdaInstances = LambdaInstance.objects.filter(status="0").count()
         status_code = rest_status.HTTP_200_OK
         return Response(
             {


### PR DESCRIPTION
## Description

On the service VM change, there was a change signifying successful start of a Lambda Instance with status 0 instead of 20. This change is rectifying the difference in the central service.
## Affected components
- Count of active lambda instances
- Tests of the above
