### PR TITLE
LAM-163 Master Node id in Lambda Instance details API Call

### DIFF
--- a/webapp/api-doc/docs/LambdaInstanceDetails.md
+++ b/webapp/api-doc/docs/LambdaInstanceDetails.md
@@ -74,7 +74,8 @@ If the authentication token is correct, a sample response is
           "ram_master": 4096,
           "vcpus_slave": 4,
           "ip_allocation": "master",
-          "disk_master": 20
+          "disk_master": 20,
+          "master_node_id": 10000
         },
         "id": "3f763964-d519-4fd2-916d-b5cfbe3b878b",
         "name": "My first Lambda Instance"

--- a/webapp/backend/serializers.py
+++ b/webapp/backend/serializers.py
@@ -106,7 +106,7 @@ class LambdaInstanceInfo(serializers.Serializer):
     disk_master = serializers.IntegerField()
     disk_slave = serializers.IntegerField()
     network_request = serializers.IntegerField(default=1)
-    public_key_name = serializers.ListField(required=False, default=None)
+    public_key_name = serializers.ListField(required=False, default=[])
 
     # Allowed values for fields
     allowed = {

--- a/webapp/backend/views.py
+++ b/webapp/backend/views.py
@@ -651,10 +651,10 @@ class LambdaInstanceViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
         if filter == "status":
             wanted_fields = ['uuid', 'name', 'status', 'failure_message']
         elif filter == "info":
-            wanted_fields = ['uuid', 'name', 'instance_info']
+            wanted_fields = ['uuid', 'name', 'instance_info', 'master_node']
         elif filter == "":
             wanted_fields = ['uuid', 'name', 'instance_info', 'status', 'failure_message',
-                             'applications']
+                             'applications', 'master_node']
         else:
             raise CustomParseError(CustomParseError.messages['filter_value_error'])
 
@@ -669,6 +669,8 @@ class LambdaInstanceViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
         if 'instance_info' in lambda_instance_all:
             lambda_instance_all['instance_info'] = json.loads(
                 lambda_instance_all['instance_info'])
+            lambda_instance_all['instance_info']['master_node_id'] = lambda_instance_all[
+                'master_node']
 
         # If status exists, create a code field and change status to a human readable format.
         if 'status' in lambda_instance_all:

--- a/webapp/tests/test_lambda_instances.py
+++ b/webapp/tests/test_lambda_instances.py
@@ -443,9 +443,18 @@ class TestLambdaInstaceDetails(APITestCase):
 
         # Save a lambda instance on the database with a specified uuid.
         self.lambda_instance_uuid = uuid.uuid4()
-        LambdaInstance.objects.create(uuid=self.lambda_instance_uuid,
-                                      name="Lambda Instance created from tests",
-                                      instance_info=json.dumps(self.instance_info))
+        lambda_instance = LambdaInstance.objects.create(uuid=self.lambda_instance_uuid,
+                                                        name="Lambda Instance created from tests",
+                                                        instance_info=json.dumps(
+                                                            self.instance_info))
+
+        # Save a server on the database.
+        self.master_node_id = randint(2, 100)
+        master_node = Server.objects.create(id=self.master_node_id, lambda_instance=lambda_instance)
+
+        # Set the server as the master node for the lambda instance.
+        lambda_instance.master_node = master_node
+        lambda_instance.save()
 
     # Test for getting the details of a lambda instance.
     def test_lambda_instance_details(self):
@@ -491,7 +500,9 @@ class TestLambdaInstaceDetails(APITestCase):
                          "{id}".format(id=self.lambda_instance_uuid))
         self.assertEqual(response.data['data'][0]['info']['name'],
                          "Lambda Instance created from tests")
-        self.assertEqual(response.data['data'][0]['info']['instance_info'], self.instance_info)
+        extended_instance_info = self.instance_info
+        extended_instance_info['master_node_id'] = self.master_node_id
+        self.assertEqual(response.data['data'][0]['info']['instance_info'], extended_instance_info)
 
     # Test for getting the details of a lambda instance using the filter parameter with value
     # status.
@@ -564,7 +575,9 @@ class TestLambdaInstaceDetails(APITestCase):
                          "{id}".format(id=self.lambda_instance_uuid))
         self.assertEqual(response.data['data'][0]['info']['name'],
                          "Lambda Instance created from tests")
-        self.assertEqual(response.data['data'][0]['info']['instance_info'], self.instance_info)
+        extended_instance_info = self.instance_info
+        extended_instance_info['master_node_id'] = self.master_node_id
+        self.assertEqual(response.data['data'][0]['info']['instance_info'], extended_instance_info)
 
     # Test for getting the details of a lambda instance using the filter parameter with a
     # wrong value.


### PR DESCRIPTION
# Description

Return the ~okeanos id of the Master Node of a Lambda Instance on Lambda Instance details API Call.
