### PR TITLE
LAM-157 API Call for fetching allowed parameter values

### DIFF
--- a/core/tests/test_utils.py
+++ b/core/tests/test_utils.py
@@ -6,9 +6,9 @@ from fokia import utils
 @mock.patch('fokia.utils.AstakosClient')
 def test_get_user_okeanos_projects(mock_AstakosClient):
     # Define ~okeanos authentication url.
-    AUTHENTICATION_URL = "https://accounts.okeanos.grnet.gr/identity/v2.0"
+    authentication_url = "https://accounts.okeanos.grnet.gr/identity/v2.0"
     # Define a fake ~okeanos token.
-    AUTHENTICATION_TOKEN = "fake-token"
+    authentication_token = "fake-token"
 
     # Set the responses of the mocks.
     mock_astakos_client = mock.Mock()
@@ -20,12 +20,89 @@ def test_get_user_okeanos_projects(mock_AstakosClient):
         {'id': 2, 'name': "name2", 'garbage2': 'garbage2'}]
 
     # Make a call to get_user_okeanos_projects utils method.
-    response = utils.get_user_okeanos_projects(AUTHENTICATION_URL, AUTHENTICATION_TOKEN)
+    response = utils.get_user_okeanos_projects(authentication_url, authentication_token)
 
     # Assert that the proper mocks have been called.
-    mock_AstakosClient.assert_called_with(AUTHENTICATION_URL, AUTHENTICATION_TOKEN)
+    mock_AstakosClient.assert_called_with(authentication_url, authentication_token)
 
     mock_astakos_client.get_projects.assert_called_with()
 
     # Assert the contents of the response.
     assert response == [{'id': 1, 'name': "name1"}, {'id': 2, 'name': "name2"}]
+
+
+@mock.patch('fokia.utils.CycladesComputeClient')
+@mock.patch('fokia.utils.AstakosClient')
+def test_get_vm_parameter_values(mock_AstakosClient, mock_CycladesComputeClient):
+    # Define ~okeanos authentication url.
+    authentication_url = "https://accounts.okeanos.grnet.gr/identity/v2.0"
+    # Define a fake ~okeanos token.
+    authentication_token = "fake-token"
+
+    # Set the responses of the mocks.
+    cyclades_url = mock.Mock()
+    mock_cyclades_compute_client = mock.Mock()
+    mock_CycladesComputeClient.service_type = mock.Mock()
+    mock_cyclades_compute_client.\
+        list_flavors.return_value = [
+            {
+                u'SNF:allow_create': True,
+                u'SNF:disk_template': u'drbd',
+                u'SNF:volume_type': 1,
+                u'disk': 20,
+                u'id': 1,
+                u'links': [{u'href': u'https://cyclades.okeanos.grnet.gr/compute/v2.0/flavors/1',
+                            u'rel': u'self'},
+                           {u'href': u'https://cyclades.okeanos.grnet.gr/compute/v2.0/flavors/1',
+                            u'rel': u'bookmark'}],
+                u'name': u'C1R1024D20drbd',
+                u'ram': 2048,
+                u'vcpus': 2
+            },
+            {
+                u'SNF:allow_create': True,
+                u'SNF:disk_template': u'drbd',
+                u'SNF:volume_type': 1,
+                u'disk': 40,
+                u'id': 3,
+                u'links': [{u'href': u'https://cyclades.okeanos.grnet.gr/compute/v2.0/flavors/3',
+                            u'rel': u'self'},
+                           {u'href': u'https://cyclades.okeanos.grnet.gr/compute/v2.0/flavors/3',
+                             u'rel': u'bookmark'}],
+                u'name': u'C1R1024D40drbd',
+                u'ram': 1024,
+                u'vcpus': 4
+            },
+            {
+                u'SNF:allow_create': False,
+                u'SNF:disk_template': u'drbd',
+                u'SNF:volume_type': 1,
+                u'disk': 80,
+                u'id': 51,
+                u'links': [{u'href': u'https://cyclades.okeanos.grnet.gr/compute/v2.0/flavors/51',
+                            u'rel': u'self'},
+                           {u'href': u'https://cyclades.okeanos.grnet.gr/compute/v2.0/flavors/51',
+                            u'rel': u'bookmark'}],
+                u'name': u'C1R512D80drbd',
+                u'ram': 512,
+                u'vcpus': 1
+            }
+        ]
+
+    mock_CycladesComputeClient.return_value = mock_cyclades_compute_client
+
+    mock_astakos_client = mock.Mock()
+    mock_astakos_client.get_endpoint_url.return_value = cyclades_url
+    mock_AstakosClient.return_value = mock_astakos_client
+
+    # Make a call to get vm parameter values method.
+    response = utils.get_vm_parameter_values(authentication_url, authentication_token)
+
+    # Assert that the proper mocks have been called.
+    mock_AstakosClient.assert_called_with(authentication_url, authentication_token)
+    mock_astakos_client.get_endpoint_url.assert_called_with(mock_CycladesComputeClient.service_type)
+    mock_CycladesComputeClient.assert_called_with(cyclades_url, authentication_token)
+    mock_cyclades_compute_client.list_flavors.assert_called_with(detail=True)
+
+    # Assert the contents of the response
+    assert response == {'vcpus': [2, 4], 'ram': [1024, 2048], 'disk': [20, 40]}

--- a/webapp/api-doc/docs/VMParameterValues.md
+++ b/webapp/api-doc/docs/VMParameterValues.md
@@ -1,0 +1,77 @@
+---
+title: 'API | VM parameter values'
+description: Retrieve the ~okeanos to which the user is a member
+---
+
+# API - VM parameter values - Description
+VM parameter values call, given an authentication token through the header Authorization, will connect to ~okeanos service and retrieve the allowed values
+of the parameters for creating a VM on ~okeanos. If the token is valid, the API will reply with a "200 Success" code along with all the available values. If the token is
+invalid, the API will reply with a "401 Unauthorized" error along with details regarding the error.
+
+
+## Basic Parameters
+|Type             | Description
+|-----------------|--------------------------
+| **Description** | VM parameter values
+| **URL**         | /api/vm-parameter-values/
+| **HTTP Method** | GET
+| **Security**    | Basic Authentication
+
+### Headers
+
+Type          | Description          | Required | Default value | Example value
+------------- | -------------------- | -------- | ------------- | ----------------------------
+Authorization | ~okeanos authentication token. If you have an account you may find the authentication token at (Dashboad-> API Access) https://accounts.okeanos.grnet.gr/ui/api_access. | `Yes`    | None          | Token tJ3b3f32f23ceuqdoS_..
+
+## Example
+In the following example we will fetch all the allowed values of the parameters
+for creating a VM on ~okeanos.
+
+```
+curl -X GET -H "Authorization:Token tJ3b3f32f23ceuqdoS_TH7m0d6yxmlWL1r2ralKcttY" 'http://<hostname>/api/vm-parameter-values/'
+```
+
+### Response body
+If the authentication token is correct then the response is
+
+```
+{
+  "status": {
+    "short_description": "Allowed values of parameters for creating a Lambda Instance",
+    "code": 200
+  },
+  "data": [
+    {
+      "disk": [
+        5,
+        10,
+        20,
+        40,
+        60
+      ],
+      "vcpus": [
+        1,
+        2,
+        4,
+        8
+      ],
+      "ram": [
+        512,
+        1024,
+        2048,
+        4096,
+        6144,
+        8192
+      ]
+    }
+  ]
+}
+```
+
+For the case where the authentication token is not correct, refer to [Authentication page](Authentication.md).
+
+### Response messages
+The main response messages are:
+
+ - HTTP/1.1 200 OK : (Success)
+ - HTTP/1.1 401 UNAUTHORIZED : (Fail)

--- a/webapp/backend/response_messages.py
+++ b/webapp/backend/response_messages.py
@@ -25,6 +25,7 @@ class ResponseMessages:
         'application_stop': "Your request to stop the specified application has been accepted",
         'user_public_keys': "Public keys uploaded to ~okeanos",
         'user_okeanos_projects': "~okeanos projects",
+        'vm_parameter_values': "Allowed values of parameters for creating a Lambda Instance",
     }
 
     lambda_instance_status_details = {

--- a/webapp/backend/urls.py
+++ b/webapp/backend/urls.py
@@ -26,6 +26,8 @@ urlpatterns = [
     url(r'^user-public-keys/?$', views.UserPublicKeysView.as_view(), name="user public keys"),
     url(r'^user-okeanos-projects/?$', views.UserOkeanosProjects.as_view(),
         name="user okeanos projects"),
+    url(r'^vm-parameter-values/?$', views.VMParameterValues.as_view(),
+        name="vm parameter values"),
     url(r'^lambda-instance/?$', views.CreateLambdaInstance.as_view(),
         name='create lambda instance'),
     url(r'^lambda-instances/?$', lambda_instances_list, name="lambda instances list"),

--- a/webapp/backend/views.py
+++ b/webapp/backend/views.py
@@ -18,7 +18,7 @@ from rest_framework.exceptions import ValidationError
 
 from rest_framework_xml.renderers import XMLRenderer
 
-from fokia.utils import check_auth_token, get_user_okeanos_projects
+from fokia.utils import check_auth_token, get_user_okeanos_projects, get_vm_parameter_values
 
 from . import tasks, events
 from .models import Application, LambdaInstance, LambdaInstanceApplicationConnection
@@ -159,6 +159,32 @@ class UserOkeanosProjects(APIView):
                 'code': status_code
             },
             'data': okeanos_projects
+        }, status=status_code)
+
+
+class VMParameterValues(APIView):
+    """
+    Implements the API calls relevant to the values of the parameters for creating a VM on
+    ~okeanos
+    """
+
+    authentication_classes = KamakiTokenAuthentication,
+    permission_classes = IsAuthenticated,
+
+    # Retrieves all the allowed values of the parameters for creating a VM
+    def get(self, request, format=None):
+        auth_token = request.META.get("HTTP_AUTHORIZATION").split()[-1]
+        auth_url = "https://accounts.okeanos.grnet.gr/identity/v2.0"
+
+        vm_parameter_values = get_vm_parameter_values(auth_url, auth_token)
+
+        status_code = status.HTTP_200_OK
+        return Response({
+            'status': {
+                'short_description': ResponseMessages.short_descriptions['vm_parameter_values'],
+                'code': status_code
+            },
+            'data': [vm_parameter_values]
         }, status=status_code)
 
 

--- a/webapp/tests/test_vm_parameter_values.py
+++ b/webapp/tests/test_vm_parameter_values.py
@@ -1,0 +1,60 @@
+import mock
+import uuid
+
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from backend.models import User
+from backend.response_messages import ResponseMessages
+
+
+class TestVMParameterValues(APITestCase):
+    """
+    Contains tests for vm parameter values API call.
+    """
+
+    # Define ~okeanos authentication url.
+    AUTHENTICATION_URL = "https://accounts.okeanos.grnet.gr/identity/v2.0"
+    # Define a fake ~okeanos token.
+    AUTHENTICATION_TOKEN = "fake-token"
+
+    def setUp(self):
+        # Create a user and force authenticate.
+        self.user = User.objects.create(uuid=uuid.uuid4())
+        self.client.force_authenticate(user=self.user)
+
+        # Add a fake token to every request authentication header to be used by the API.
+        self.client.credentials(HTTP_AUTHORIZATION='Token {token}'.format(token=self.
+                                                                          AUTHENTICATION_TOKEN))
+
+    # Test for getting vm parameter values.
+    @mock.patch('backend.views.get_vm_parameter_values', return_value={
+        "disk": [5, 10, 20, 40, 60],
+        "vcpus": [1, 2, 4, 8],
+        "ram": [512, 1024, 2048, 4096, 6144, 8192]
+    })
+    def test_vm_parameter_values(self, mock_get_vm_parameter_values):
+        # Make a request to get the vm parameter values.
+        response = self.client.get("/api/vm-parameter-values/")
+
+        # Assert that the proper mocks have been called.
+        mock_get_vm_parameter_values.\
+            assert_called_with(self.AUTHENTICATION_URL, self.AUTHENTICATION_TOKEN)
+
+        # Assert the structure of the response.
+        self.assertIn('status', response.data)
+        self.assertIn('data', response.data)
+
+        self.assertIn('code', response.data['status'])
+        self.assertIn('short_description', response.data['status'])
+
+        # Assert the contents of the response.
+        self.assertEqual(response.data['status']['code'], status.HTTP_200_OK)
+        self.assertEqual(response.data['status']['short_description'],
+                         ResponseMessages.short_descriptions['vm_parameter_values'])
+
+        self.assertEqual(response.data['data'], [{
+            "disk": [5, 10, 20, 40, 60],
+            "vcpus": [1, 2, 4, 8],
+            "ram": [512, 1024, 2048, 4096, 6144, 8192]
+        }])


### PR DESCRIPTION
# Description

When creating a new lambda instance through the web UI, the user should be able to choose the number of CPUs, the amount of RAM and the size of the Disk for the Master node and the Slave nodes. A list with all the available values for each of these parameters should be presented to the user.
# Implementation

Create an API call to fetch the available values from ~okeanos. The web UI will make that API call to fetch the available values and present them to the user.
