### PR TITLE
VM Parameter Values dynamically fetching on API call

### DIFF
--- a/webapp/backend/serializers.py
+++ b/webapp/backend/serializers.py
@@ -108,13 +108,14 @@ class LambdaInstanceInfo(serializers.Serializer):
     network_request = serializers.IntegerField(default=1)
     public_key_name = serializers.ListField(required=False, default=[])
 
-    # Allowed values for fields
+    # Allowed values for vm parameters. They will be changed dynamically in the view that will
+    # be called to create a new lambda instance. These entries are kept here in case the view
+    # fails to fetch the values.
     allowed = {
         "vcpus": [2, 4, 8],
-        "disks": [5, 10, 20, 40, 60, 80, 100],
-        "ram": [512, 1024, 2048, 4096, 6144, 8192],
-        "disk_types": [u'drbd', u'ext_vlmc'],
-        "ip_allocation": ['all', 'none', 'master']
+        "disk": [10, 20, 40, 60, 80, 100],
+        "ram": [2048, 4096, 6144, 8192],
+        "ip_allocation": ['master']  # TODO add 'all' choice.
     }
 
     def validate_vcpus_master(self, value):
@@ -142,15 +143,15 @@ class LambdaInstanceInfo(serializers.Serializer):
         return value
 
     def validate_disk_master(self, value):
-        if value not in self.allowed['disks']:
+        if value not in self.allowed['disk']:
             raise serializers.ValidationError("Wrong Size of master disk, "
-                                              "available choices {}.".format(self.allowed['disks']))
+                                              "available choices {}.".format(self.allowed['disk']))
         return value
 
     def validate_disk_slave(self, value):
-        if value not in self.allowed['disks']:
+        if value not in self.allowed['disk']:
             raise serializers.ValidationError("Wrong Size of slave disk, "
-                                              "available choices {}.".format(self.allowed['disks']))
+                                              "available choices {}.".format(self.allowed['disk']))
         return value
 
     def validate_ip_allocation(self, value):

--- a/webapp/backend/views.py
+++ b/webapp/backend/views.py
@@ -978,6 +978,33 @@ class CreateLambdaInstance(APIView):
 
         # Get okeanos authentication token
         auth_token = request.META.get("HTTP_AUTHORIZATION").split()[-1]
+        auth_url = "https://accounts.okeanos.grnet.gr/identity/v2.0"
+
+        # Dynamically fetch the allowed values for the number of CPUs, the amount of RAM and the
+        # size of the Disk for each VM.
+        vm_parameter_values = get_vm_parameter_values(auth_url, auth_token)
+
+        # Keep the vcpus values that are equal or greater than 2.
+        vcpus = list()
+        for value in vm_parameter_values['vcpus']:
+            if value >= 2:
+                vcpus.append(value)
+
+        # Keep the ram values that are equal or greater that 2048.
+        ram = list()
+        for value in vm_parameter_values['ram']:
+            if value >= 2048:
+                ram.append(value)
+
+        # Keep the disk values that are equal or greater than 10.
+        disk = list()
+        for value in vm_parameter_values['disk']:
+            if value >= 10:
+                disk.append(value)
+
+        LambdaInstanceInfo.allowed['vcpus'] = vcpus
+        LambdaInstanceInfo.allowed['ram'] = ram
+        LambdaInstanceInfo.allowed['disk'] = disk
 
         # Parse request json into a custom serializer
         lambda_info = LambdaInstanceInfo(data=request.data)


### PR DESCRIPTION
# Description

When a create lambda instance API call is made, the allowed values for the vm parameter(CPUs, RAM and Disk) are dynamically fetched on Django validator.
