### PR TITLE
LAM-199 Deleted instances should not be returned by the API

### DIFF
--- a/webapp/backend/views.py
+++ b/webapp/backend/views.py
@@ -667,7 +667,7 @@ class LambdaInstanceViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
     authentication_classes = KamakiTokenAuthentication,
     permission_classes = IsAuthenticated,
 
-    queryset = LambdaInstance.objects.all()
+    queryset = LambdaInstance.objects.all().exclude(status='6')
     serializer_class = LambdaInstanceSerializer
 
     lookup_field = 'uuid'

--- a/webapp/tests/test_lambda_instances.py
+++ b/webapp/tests/test_lambda_instances.py
@@ -289,9 +289,14 @@ class TestLambdaInstancesList(APITestCase):
     def test_lambda_instances_list(self):
         # Create some lambda instances on the database.
         number_of_lambda_instances = randint(0, 100)
+        number_of_deleted_lambda_instances = randint(0, 20)
         for i in range(number_of_lambda_instances):
             LambdaInstance.objects.create(uuid=uuid.uuid4(),
                                           name="lambda_instance_{i}".format(i=i))
+        for i in range(number_of_deleted_lambda_instances):
+            LambdaInstance.objects.create(uuid=uuid.uuid4(),
+                                          name="lambda_instance_{i}".format(i=i),
+                                          status='6')
 
         # Make a request to list the lambda instances.
         response = self.client.get("/api/lambda-instances/")
@@ -300,7 +305,8 @@ class TestLambdaInstancesList(APITestCase):
         self._assert_success_request_response_structure(response)
 
         # Assert the contents of the response.
-        self.assertEqual(len(response.data['data']), number_of_lambda_instances)
+        self.assertEqual(len(response.data['data']),
+                         number_of_lambda_instances)
 
         self._assert_success_request_response_content(response)
 


### PR DESCRIPTION
## Description

Deleted instances are not deleted in the database. They are just simply tagged as 'deleted' in their status field.
The aim of this PR is not to serve deleted instances from the API in lambda instances list view.
