### PR TITLE
LAM-203 Delete API call should update the status of Lamdba Instance in Central Service

### DIFF
--- a/central_service/app/api-doc/docs/index.md
+++ b/central_service/app/api-doc/docs/index.md
@@ -17,7 +17,8 @@
 **The service vm will have to know the user's ~okeanos token.**
 
 * Destroy lambda instance **DELETE /api/lambda-instances/[uuid]**
-> The service vm will issue an API call towards the central service, deleting the lambda instance.  
+> The service vm will issue an API call towards the central service, deleting the lambda instance. The instance is the flagged
+  as deleted in its status.
 **The whole lambda cluster can be deleted from inside the kamaki API or the Web interface**  
 
 * Update lambda instance **POST /api/lambda_instances/[uuid]/status**

--- a/central_service/app/backend/events.py
+++ b/central_service/app/backend/events.py
@@ -43,7 +43,8 @@ def deleteLambdaInstance(uuid):
     :param uuid: The Unique identifier of the Lambda Instance to be deleted.
     """
     lambda_instance = LambdaInstance.objects.get(uuid=uuid)
-    lambda_instance.delete()
+    lambda_instance.status = '6'
+    lambda_instance.save()
 
 
 @shared_task

--- a/central_service/app/backend/views.py
+++ b/central_service/app/backend/views.py
@@ -244,7 +244,7 @@ class LambdaInstanceView(mixins.ListModelMixin,
         :return: A response object according to the outcome of the call.
         """
         lambda_instances = self.get_queryset().filter(uuid=uuid)
-        if not lambda_instances.exists():
+        if not lambda_instances.exists() or lambda_instances[0].status == '6':
             raise CustomNotFoundError(CustomNotFoundError.messages['lambda_instance_not_found'])
 
         destroy_event = events.deleteLambdaInstance.delay(uuid)


### PR DESCRIPTION
## Description

Change of the Central Service API so as for the API delete action to change the status of the relevant instance to "deleted" instead of deleting the whole record.
