### PR TITLE
LAM-189 Stream Job stopped using Apache Flink CLI

### DIFF
--- a/ansible/roles/apache-flink/files/run_batch_job.sh
+++ b/ansible/roles/apache-flink/files/run_batch_job.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+export JARFILE=example.jar
+
+/usr/local/flink/bin/flink run $JARFILE
+

--- a/ansible/roles/apache-flink/files/run_flink_job.sh
+++ b/ansible/roles/apache-flink/files/run_flink_job.sh
@@ -2,14 +2,19 @@
 
 export JARFILE=example.jar
 
-execution_environment_name=0
+execution_environment_name=""
 
-/usr/local/flink/bin/flink run $JARFILE
-
-if [ $execution_environment_name != 0 ]
-then
-  id=$(/usr/local/flink/bin/flink list | grep "$execution_environment_name" | cut -f4 -d" ")
+function finish {
+  id="$(/usr/local/flink/bin/flink list | grep "$execution_environment_name" | cut -f4 -d" ")"
+  echo "$id" >> temp
 
   /usr/local/flink/bin/flink cancel $id
+}
+
+if [ "$execution_environment_name" != "" ]
+then
+  trap finish EXIT
 fi
+
+/usr/local/flink/bin/flink run $JARFILE
 

--- a/ansible/roles/apache-flink/files/run_flink_job.sh
+++ b/ansible/roles/apache-flink/files/run_flink_job.sh
@@ -2,4 +2,14 @@
 
 export JARFILE=example.jar
 
+execution_environment_name=0
+
 /usr/local/flink/bin/flink run $JARFILE
+
+if [ $execution_environment_name != 0 ]
+then
+  id=$(/usr/local/flink/bin/flink list | grep "$execution_environment_name" | cut -f4 -d" ")
+
+  /usr/local/flink/bin/flink cancel $id
+fi
+

--- a/ansible/roles/apache-flink/files/run_streaming_job.sh
+++ b/ansible/roles/apache-flink/files/run_streaming_job.sh
@@ -6,7 +6,6 @@ execution_environment_name=""
 
 function finish {
   id="$(/usr/local/flink/bin/flink list | grep "$execution_environment_name" | cut -f4 -d" ")"
-  echo "$id" >> temp
 
   /usr/local/flink/bin/flink cancel $id
 }

--- a/ansible/roles/apache-flink/tasks/master.yml
+++ b/ansible/roles/apache-flink/tasks/master.yml
@@ -22,12 +22,12 @@
       - configure
 
   - name: Copy run_batch_job script
-    copy: src=run_flink_job.sh dest="/home/flink/run_batch_job.sh" owner=flink group=flink mode=0744
+    copy: src=run_batch_job.sh dest="/home/flink/run_batch_job.sh" owner=flink group=flink mode=0744
     tags:
       - configure
 
   - name: Copy run_streaming_job script
-    copy: src=run_flink_job.sh dest="/home/flink/run_streaming_job.sh" owner=flink group=flink mode=0744
+    copy: src=run_streaming_job.sh dest="/home/flink/run_streaming_job.sh" owner=flink group=flink mode=0744
     tags:
       - configure
 

--- a/ansible/roles/common/templates/supervisord-master.conf.j2
+++ b/ansible/roles/common/templates/supervisord-master.conf.j2
@@ -91,8 +91,6 @@ directory=/home/flink
 command=bash run_streaming_job.sh
 autostart=false
 user=flink
-stopsignal=INT
-stopasgroup=true
 stdout_logfile=/home/flink/supervisord_flink_streaming_logs.log
 
 ;[program:theprogramname]

--- a/ansible/roles/flink-apps/tasks/start-streaming.yml
+++ b/ansible/roles/flink-apps/tasks/start-streaming.yml
@@ -7,5 +7,12 @@
               state=present
               insertafter="^export"
 
+  - name: Set execution environment name for streaming job
+    lineinfile: destfile="/home/flink/run_streaming_job.sh"
+                regexp="^execution_environment_name"
+                line=execution_environment_name='"{{ execution_environment_name }}"'
+                state=present
+                insertafter="^execution_environment_name"
+
   - name: Start streaming job using supervisord
     supervisorctl: name='flink_streaming_job' state=started

--- a/core/fokia/ansible_manager.py
+++ b/core/fokia/ansible_manager.py
@@ -96,7 +96,8 @@ class Manager:
         playbook_result = pb.run()
         return playbook_result
 
-    def create_master_inventory(self, app_action=None, app_type=None, jar_filename=None):
+    def create_master_inventory(self, app_action=None, app_type=None, jar_filename=None,
+                                execution_environment_name=None):
         master_hostname = self.inventory['master']['name'] + '.vm.okeanos.grnet.gr'
         self.ansible_inventory = ansible.inventory.Inventory(host_list=[master_hostname])
         all_group = self.ansible_inventory.get_group('all')
@@ -107,6 +108,10 @@ class Manager:
             master_host.set_variable('app_type', app_type)
             if jar_filename is not None:
                 master_host.set_variable('jarfile', jar_filename)
+
+                if execution_environment_name is not None:
+                    master_host.set_variable('execution_environment_name',
+                                             execution_environment_name)
 
         master_group = ansible.inventory.group.Group(name='master')
         master_group.add_host(master_host)

--- a/webapp/backend/events.py
+++ b/webapp/backend/events.py
@@ -75,7 +75,8 @@ def insert_cluster_info(instance_uuid, specs, provisioner_response):
 
 
 @shared_task
-def create_new_application(uuid, name, path, description, app_type, owner):
+def create_new_application(uuid, name, path, description, app_type, owner,
+                           execution_environment_name):
     """
     Creates a new entry of an application on the database.
     :param uuid: The uuid of the new application.
@@ -83,7 +84,7 @@ def create_new_application(uuid, name, path, description, app_type, owner):
     :param path: The path where the new application is stored on Pithos.
     :param description: The provided description of the new application.
     :param owner: The owner of the new application.
-    :param type: The type of the new application
+    :param execution_environment_name: The name given to the Apache Flink execution environment.
     """
 
     if app_type == 'batch':
@@ -92,7 +93,8 @@ def create_new_application(uuid, name, path, description, app_type, owner):
         app_type = Application.STREAMING
 
     Application.objects.create(uuid=uuid, name=name, path=path, description=description,
-                               owner=owner, type=app_type)
+                               owner=owner, type=app_type,
+                               execution_environment_name=execution_environment_name)
 
 
 @shared_task

--- a/webapp/backend/events.py
+++ b/webapp/backend/events.py
@@ -83,6 +83,7 @@ def create_new_application(uuid, name, path, description, app_type, owner,
     :param name: The name of the new application.
     :param path: The path where the new application is stored on Pithos.
     :param description: The provided description of the new application.
+    :param app_type: The type of the new application.
     :param owner: The owner of the new application.
     :param execution_environment_name: The name given to the Apache Flink execution environment.
     """

--- a/webapp/backend/models.py
+++ b/webapp/backend/models.py
@@ -61,6 +61,7 @@ class Application(models.Model):
     owner = models.ForeignKey(User, default=None, on_delete=models.SET_NULL, null=True, blank=True)
     failure_message = models.TextField(default="", null=True, blank=True,
                                        help_text="Error message regarding this application.")
+    execution_environment_name = models.CharField(max_length=100, default="", null=True, blank=True)
 
     UPLOADED = "0"
     UPLOADING = "1"

--- a/webapp/backend/serializers.py
+++ b/webapp/backend/serializers.py
@@ -49,7 +49,7 @@ class ApplicationSerializer(serializers.ModelSerializer):
     class Meta:
         model = Application
         fields = ('uuid', 'name', 'path', 'type', 'description', 'failure_message', 'status',
-                  'lambda_instances')
+                  'lambda_instances', 'execution_environment_name')
 
 
 class ServerSerializer(serializers.ModelSerializer):

--- a/webapp/backend/tasks.py
+++ b/webapp/backend/tasks.py
@@ -440,12 +440,14 @@ def withdraw_application(lambda_instance_uuid, application_uuid):
 
 @shared_task
 def start_stop_application(lambda_instance_uuid, app_uuid,
-                           app_action, app_type, jar_filename=None):
+                           app_action, app_type, jar_filename=None,
+                           execution_environment_name=""):
     master_node_id = get_master_node_info(lambda_instance_uuid)[0]
     response = {'nodes': {'master': {'id': master_node_id, 'internal_ip': None}}}
     ansible_manager = Manager(response)
     ansible_manager.create_master_inventory(app_action=app_action, app_type=app_type,
-                                            jar_filename=jar_filename)
+                                            jar_filename=jar_filename,
+                                            execution_environment_name=execution_environment_name)
     ansible_result = lambda_instance_manager.run_playbook(ansible_manager, 'flink-apps.yml')
     check = _check_ansible_result(ansible_result)
     if check == 'Ansible successful':

--- a/webapp/backend/tasks.py
+++ b/webapp/backend/tasks.py
@@ -292,7 +292,8 @@ setattr(create_lambda_instance, 'on_failure', on_failure)
 
 @shared_task
 def upload_application_to_pithos(auth_url, auth_token, container_name, project_name,
-                                 local_file_path, application_uuid):
+                                 local_file_path, application_uuid, application_name,
+                                 application_description):
     """
     Uploads an application to Pithos.
     :param auth_url: The authentication url for ~okeanos API.
@@ -304,10 +305,9 @@ def upload_application_to_pithos(auth_url, auth_token, container_name, project_n
 
     # The application has been created in the view that called this task. Send the information to
     # Central VM.
-    application = Application.objects.get(uuid=application_uuid)
     central_vm_tasks.\
-        create_application_central_vm.delay(auth_token, application_uuid, application.name,
-                                            application.description)
+        create_application_central_vm.delay(auth_token, application_uuid, application_name,
+                                            application_description)
 
     # Open file from the local file system.
     local_file = open(local_file_path, 'r')

--- a/webapp/backend/views.py
+++ b/webapp/backend/views.py
@@ -314,7 +314,8 @@ class ApplicationViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
         auth_url = "https://accounts.okeanos.grnet.gr/identity/v2.0"
 
         tasks.upload_application_to_pithos.delay(auth_url, auth_token, self.pithos_container,
-                                                 project_name, local_file_path, application_uuid)
+                                                 project_name, local_file_path, application_uuid,
+                                                 uploaded_file.name, description)
 
         # Return an appropriate response.
         status_code = status.HTTP_202_ACCEPTED

--- a/webapp/frontend/app/templates/lambda-apps/upload.hbs
+++ b/webapp/frontend/app/templates/lambda-apps/upload.hbs
@@ -70,6 +70,15 @@
 
 
           <span id="helpBlock" class="help-block">Add a description for the file.</span>
+          </div>
+
+          <label for="description" class="col-sm-6">Execution Environment Name:</label>
+              <div class="col-sm-6">
+
+          <textarea type="textarea" name="execution_environment_name" class="center-block form-control input-lg" id="execution_environment_name" placeholder="Add the name used for the Apache Flink Execution Environment"></textarea>
+
+
+          <span id="helpBlock" class="help-block">Add the name of the Execution Environment.</span>
 
 
           </div>	<!--class="col-sm-6"-->

--- a/webapp/tests/test_applications.py
+++ b/webapp/tests/test_applications.py
@@ -38,6 +38,8 @@ class TestApplicationUpload(APITestCase):
     application_type_streaming = "streaming"
     # project_name
     project_name = "lambda.grnet.gr"
+    # execution_environment_name
+    execution_environment_name = "Stream"
 
     def setUp(self):
         # Create a user and force authenticate.
@@ -58,7 +60,9 @@ class TestApplicationUpload(APITestCase):
         response = self.client.post("/api/apps/", {'description': self.application_description,
                                                    'file': self.application,
                                                    'type': self.application_type_batch,
-                                                   'project_name': self.project_name})
+                                                   'project_name': self.project_name,
+                                                   'execution_environment_name':
+                                                   self.execution_environment_name})
 
         # Assert the structure of the response.
         self._assert_accepted_response_structure(response)
@@ -81,7 +85,7 @@ class TestApplicationUpload(APITestCase):
             assert_called_with(application_id, self.application.name,
                                ApplicationViewSet.pithos_container,
                                self.application_description, self.application_type_batch,
-                               self.user)
+                               self.user, self.execution_environment_name)
 
         mock_upload_application_to_pithos_task.delay.\
             assert_called_with(self.AUTHENTICATION_URL, self.AUTHENTICATION_TOKEN,
@@ -104,7 +108,9 @@ class TestApplicationUpload(APITestCase):
         response = self.client.post("/api/apps/", {'description': self.application_description,
                                                    'file': existing_application,
                                                    'type': self.application_type_batch,
-                                                   'project_name': self.project_name})
+                                                   'project_name': self.project_name,
+                                                   'execution_environment_name': self.\
+                                                   execution_environment_name})
 
         # Assert the structure of the response.
         self._assert_bad_request_response_structure(response)
@@ -123,7 +129,9 @@ class TestApplicationUpload(APITestCase):
         # Make a request to upload an application.
         response = self.client.post("/api/apps/", {'file': self.application,
                                                    'type': self.application_type_batch,
-                                                   'project_name': self.project_name})
+                                                   'project_name': self.project_name,
+                                                   'execution_environment_name': self.\
+                                                   execution_environment_name})
 
         # Assert the structure of the response.
         self._assert_accepted_response_structure(response)
@@ -145,7 +153,8 @@ class TestApplicationUpload(APITestCase):
         mock_create_new_application_event.delay.\
             assert_called_with(application_id, self.application.name,
                                ApplicationViewSet.pithos_container, "",
-                               self.application_type_batch, self.user)
+                               self.application_type_batch, self.user,
+                               self.execution_environment_name)
 
         mock_upload_application_to_pithos_task.delay.\
             assert_called_with(self.AUTHENTICATION_URL, self.AUTHENTICATION_TOKEN,
@@ -180,7 +189,9 @@ class TestApplicationUpload(APITestCase):
         response = self.client.post("/api/apps/", {'description': self.application_description,
                                                    'file': self.application,
                                                    'type': self.application_type_streaming,
-                                                   'project_name': self.project_name})
+                                                   'project_name': self.project_name,
+                                                   'execution_environment_name': self.\
+                                                   execution_environment_name})
 
         # Assert the structure of the response.
         self._assert_accepted_response_structure(response)
@@ -203,7 +214,7 @@ class TestApplicationUpload(APITestCase):
             assert_called_with(application_id, self.application.name,
                                ApplicationViewSet.pithos_container,
                                self.application_description, self.application_type_streaming,
-                               self.user)
+                               self.user, self.execution_environment_name)
 
         mock_upload_application_to_pithos_task.delay.\
             assert_called_with(self.AUTHENTICATION_URL, self.AUTHENTICATION_TOKEN,
@@ -252,7 +263,9 @@ class TestApplicationUpload(APITestCase):
         # Make a request to upload an application.
         response = self.client.post("/api/apps/", {'description': self.application_description,
                                                    'file': self.application,
-                                                   'type': self.application_type_batch})
+                                                   'type': self.application_type_batch,
+                                                   'execution_environment_name': self.\
+                                                   execution_environment_name})
 
         # Assert the structure of the response.
         self._assert_accepted_response_structure(response)
@@ -275,7 +288,7 @@ class TestApplicationUpload(APITestCase):
             assert_called_with(application_id, self.application.name,
                                ApplicationViewSet.pithos_container,
                                self.application_description, self.application_type_batch,
-                               self.user)
+                               self.user, self.execution_environment_name)
 
         mock_upload_application_to_pithos_task.delay.\
             assert_called_with(self.AUTHENTICATION_URL, self.AUTHENTICATION_TOKEN,
@@ -1248,7 +1261,8 @@ class TestApplicationStart(APITestCase):
         self.application = Application.objects.create(uuid=self.application_uuid,
                                                       name="application.jar",
                                                       description="A description.",
-                                                      type=Application.BATCH)
+                                                      type=Application.BATCH,
+                                                      execution_environment_name="Stream")
 
         self.lambda_instance = LambdaInstance.objects.create(uuid=self.lambda_instance_uuid,
                                                              name="Lambda Instance 1",
@@ -1285,7 +1299,8 @@ class TestApplicationStart(APITestCase):
                                app_uuid="{application_id}".
                                format(application_id=self.application_uuid),
                                app_action="start", app_type="batch",
-                               jar_filename="application.jar")
+                               jar_filename="application.jar",
+                               execution_environment_name="Stream")
 
     # Test for starting an application on a specified lambda instance that it is already deployed.
     @mock.patch('backend.views.tasks.start_stop_application')
@@ -1319,7 +1334,8 @@ class TestApplicationStart(APITestCase):
                                app_uuid="{application_id}".
                                format(application_id=self.application_uuid),
                                app_action="start", app_type="streaming",
-                               jar_filename="application.jar")
+                               jar_filename="application.jar",
+                               execution_environment_name="Stream")
 
     # Test for request to start an application when the lambda instance id is not provided.
     def test_no_lambda_instance_id(self):
@@ -1549,7 +1565,8 @@ class TestApplicationStop(APITestCase):
         self.application = Application.objects.create(uuid=self.application_uuid,
                                                       name="application.jar",
                                                       description="A description.",
-                                                      type=Application.BATCH)
+                                                      type=Application.BATCH,
+                                                      execution_environment_name="Stream")
 
         self.lambda_instance = LambdaInstance.objects.create(uuid=self.lambda_instance_uuid,
                                                              name="Lambda Instance 1",
@@ -1588,7 +1605,8 @@ class TestApplicationStop(APITestCase):
             assert_called_with(lambda_instance_uuid=self.lambda_instance_uuid,
                                app_uuid="{application_id}".
                                format(application_id=self.application_uuid),
-                               app_action="stop", app_type="batch")
+                               app_action="stop", app_type="batch",
+                               execution_environment_name="Stream")
 
     # Test for stopping an application on a specified lambda instance that it is already started.
     @mock.patch('backend.views.tasks.start_stop_application')
@@ -1621,7 +1639,8 @@ class TestApplicationStop(APITestCase):
             assert_called_with(lambda_instance_uuid=self.lambda_instance_uuid,
                                app_uuid="{application_id}".
                                format(application_id=self.application_uuid),
-                               app_action="stop", app_type="streaming")
+                               app_action="stop", app_type="streaming",
+                               execution_environment_name="Stream")
 
     # Test for request to stop an application when the lambda instance id is not provided.
     def test_no_lambda_instance_id(self):

--- a/webapp/tests/test_celery_events.py
+++ b/webapp/tests/test_celery_events.py
@@ -128,10 +128,11 @@ class TestCeleryEvents(APITestCase):
         application_description = "application_description"
         application_type = "batch"
         application_owner = User.objects.create(uuid=uuid.uuid4())
+        application_execution_environment_name = "Stream"
 
         events.create_new_application(application_uuid, application_name, application_path,
                                       application_description, application_type,
-                                      application_owner)
+                                      application_owner, application_execution_environment_name)
 
         self.assertEqual(Application.objects.all().count(), 1)
 
@@ -142,6 +143,8 @@ class TestCeleryEvents(APITestCase):
         self.assertEqual(application.owner, application_owner)
         self.assertEqual(application.status, Application.UPLOADING)
         self.assertEqual(application.type, Application.BATCH)
+        self.assertEqual(application.execution_environment_name,
+                         application_execution_environment_name)
 
     def test_delete_application(self):
         # Create an application on the database.

--- a/webapp/tests/test_celery_tasks.py
+++ b/webapp/tests/test_celery_tasks.py
@@ -509,7 +509,7 @@ class TestCeleryTasks(APITestCase):
 
         # Make a call to start the application.
         tasks.start_stop_application(lambda_instance_uuid, application_uuid, 'start', 'batch',
-                                     'application.jar')
+                                     'application.jar', "Stream")
 
         # Assert that the proper mocks have been called.
         mock_manager_fokia.assert_called_with({
@@ -522,7 +522,7 @@ class TestCeleryTasks(APITestCase):
         })
         mock_ansible_manager.create_master_inventory.\
             assert_called_with(app_action="start", app_type="batch",
-                                            jar_filename="application.jar")
+                               jar_filename="application.jar", execution_environment_name="Stream")
         mock_lambda_instance_manager_fokia.run_playbook.\
             assert_called_with(mock_ansible_manager, "flink-apps.yml")
         mock_check_ansible_result.assert_called_with(mock_ansible_result)

--- a/webapp/tests/test_celery_tasks.py
+++ b/webapp/tests/test_celery_tasks.py
@@ -229,7 +229,8 @@ class TestCeleryTasks(APITestCase):
 
         tasks.upload_application_to_pithos(self.AUTHENTICATION_URL, self.AUTHENTICATION_TOKEN,
                                            container_name, project_name, local_file_path,
-                                           application_uuid)
+                                           application_uuid, application_name,
+                                           application_description)
 
         mock_create_application_central_vm.delay.\
             assert_called_with(self.AUTHENTICATION_TOKEN, application_uuid, application_name,
@@ -277,7 +278,8 @@ class TestCeleryTasks(APITestCase):
 
         tasks.upload_application_to_pithos(self.AUTHENTICATION_URL, self.AUTHENTICATION_TOKEN,
                                            container_name, project_name, local_file_path,
-                                           application_uuid)
+                                           application_uuid, application_name,
+                                           application_description)
 
         mock_create_application_central_vm.delay.\
             assert_called_with(self.AUTHENTICATION_TOKEN, application_uuid, application_name,


### PR DESCRIPTION
# Description

At the moment, Flink streaming job cannot be stopped with any other way, except the "cancel" command from Flink cli https://issues.apache.org/jira/browse/FLINK-2111.

As a temporary solution, the API should invoke this command to stop the streaming application without removing the existing supervisord implementation which is expected to work as soon as the above Flink Jira task is done.
# Solution

A new parameter will be added to each application. Its name will be execution_name_environment and will be used to start and stop the Application if it is a streaming one.
