### PR TITLE
LAM-190 User can choose the Apache Kafka topics to be created

### DIFF
--- a/ansible/roles/apache-kafka/handlers/main.yml
+++ b/ansible/roles/apache-kafka/handlers/main.yml
@@ -1,14 +1,4 @@
 ---
 - name: create topics
-  shell: "{{ installation_path }}/kafka/bin/kafka-topics.sh --create --zookeeper {{ hostvars[groups['master'][0]]['internal_ip'] }}:2181 --replica-assignment 0:1 --topic input"
-  notify:
-    - create batch output topic
-
-- name: create batch output topic
-  shell: "{{ installation_path }}/kafka/bin/kafka-topics.sh --create --zookeeper {{ hostvars[groups['master'][0]]['internal_ip'] }}:2181 --replica-assignment 0:1 --topic batch-output"
-  notify:
-    - create stream output topic
-
-- name: create stream output topic
-  shell: "{{ installation_path }}/kafka/bin/kafka-topics.sh --create --zookeeper {{ hostvars[groups['master'][0]]['internal_ip'] }}:2181 --replica-assignment 0:1 --topic stream-output"
-
+  shell: "{{ installation_path }}/kafka/bin/kafka-topics.sh --create --zookeeper {{ hostvars[groups['master'][0]]['internal_ip'] }}:2181 --replica-assignment 0:1 --topic {{ item }}"
+  with_items: "{{ topics }}"

--- a/ansible/roles/apache-kafka/vars/main.yml
+++ b/ansible/roles/apache-kafka/vars/main.yml
@@ -4,4 +4,4 @@ scala_version: "2.10"
 version: "0.8.2.1"
 download_path: "/root"
 installation_path: "/usr/local"
-
+topics: ["input", "stream-output", "batch-output"]

--- a/core/fokia/ansible_manager.py
+++ b/core/fokia/ansible_manager.py
@@ -82,17 +82,17 @@ class Manager:
         # print self.ansible_inventory.groups_list()
         return self.ansible_inventory
 
-    def run_playbook(self, playbook_file, tags=None):
+    def run_playbook(self, playbook_file, tags=None, extra_vars=None):
         """
-        Run the playbook_file using created inventory and tags specified
-        :return:
+        Run the playbook_file using created inventory, tags and extra variables specified
+        :return: The results of the playbook run
         """
         stats = callbacks.AggregateStats()
         playbook_cb = callbacks.PlaybookCallbacks(verbose=utils.VERBOSITY)
         runner_cb = callbacks.PlaybookRunnerCallbacks(stats, verbose=utils.VERBOSITY)
         pb = PlayBook(playbook=playbook_file, inventory=self.ansible_inventory, stats=stats,
                       callbacks=playbook_cb,
-                      runner_callbacks=runner_cb, only_tags=tags)
+                      runner_callbacks=runner_cb, only_tags=tags, extra_vars=extra_vars)
         playbook_result = pb.run()
         return playbook_result
 

--- a/core/fokia/lambda_instance_manager.py
+++ b/core/fokia/lambda_instance_manager.py
@@ -86,9 +86,9 @@ def __delete_private_key(cluster_id, master_id, slave_ids):
     os.remove(join(expanduser('~/.ssh/lambda_instances/'), cluster_id))
 
 
-def run_playbook(ansible_manager, playbook):
+def run_playbook(ansible_manager, playbook, tags=None, extra_vars=None):
     ansible_result = ansible_manager.run_playbook(
-        playbook_file=join(ansible_path, "playbooks", playbook))
+        playbook_file=join(ansible_path, "playbooks", playbook), tags=tags, extra_vars=extra_vars)
     return ansible_result
 
 

--- a/webapp/backend/serializers.py
+++ b/webapp/backend/serializers.py
@@ -108,6 +108,8 @@ class LambdaInstanceInfo(serializers.Serializer):
     disk_slave = serializers.IntegerField()
     network_request = serializers.IntegerField(default=1)
     public_key_name = serializers.ListField(required=False, default=[])
+    kafka_topics = serializers.ListField(required=False, default=["input", "stream-output",
+                                                                  "batch-output"])
 
     # Allowed values for vm parameters. They will be changed dynamically in the view that will
     # be called to create a new lambda instance. These entries are kept here in case the view

--- a/webapp/backend/tasks.py
+++ b/webapp/backend/tasks.py
@@ -230,7 +230,8 @@ def create_lambda_instance(lambda_info, auth_token):
             set_lambda_instance_status_central_vm.delay(auth_token, instance_uuid,
                                                         LambdaInstance.HADOOP_INSTALLED, "")
 
-    ansible_result = lambda_instance_manager.run_playbook(ansible_manager, 'kafka-install.yml')
+    ansible_result = lambda_instance_manager.run_playbook(ansible_manager, 'kafka-install.yml',
+                                                          None, {'topics': specs['kafka_topics']})
     check = _check_ansible_result(ansible_result)
     if check != 'Ansible successful':
         events.set_lambda_instance_status.delay(instance_uuid=instance_uuid,

--- a/webapp/frontend/app/components/create-lambda-instance-form.js
+++ b/webapp/frontend/app/components/create-lambda-instance-form.js
@@ -25,6 +25,9 @@ export default Ember.Component.extend({
       }
       newLambdaInstance.set('publicKeyName', requestedPublicKeys);
 
+      var kafkaTopicsString = this.get("kafkaTopics");
+      newLambdaInstance.set('kafkaTopics', kafkaTopicsString.split(','));
+
       this.sendAction('saveAction', newLambdaInstance);
     }
   }

--- a/webapp/frontend/app/components/create-lambda-instance-form.js
+++ b/webapp/frontend/app/components/create-lambda-instance-form.js
@@ -25,8 +25,10 @@ export default Ember.Component.extend({
       }
       newLambdaInstance.set('publicKeyName', requestedPublicKeys);
 
-      var kafkaTopicsString = this.get("kafkaTopics");
-      newLambdaInstance.set('kafkaTopics', kafkaTopicsString.split(','));
+      if (typeof this.get("kafkaTopics") !== 'undefined') {
+        var kafkaTopicsString = this.get("kafkaTopics");
+        newLambdaInstance.set('kafkaTopics', kafkaTopicsString.split(','));
+      }
 
       this.sendAction('saveAction', newLambdaInstance);
     }

--- a/webapp/frontend/app/models/create-lambda-instance.js
+++ b/webapp/frontend/app/models/create-lambda-instance.js
@@ -12,5 +12,6 @@ export default DS.Model.extend({
   DiskMaster: DS.attr('number',  {defaultValue: 20}),
   DiskSlave: DS.attr('number',  {defaultValue: 20}),
   ipAllocation: DS.attr('string',  {defaultValue: "master"}),
-  publicKeyName: DS.attr({defaultValue: []})
+  publicKeyName: DS.attr({defaultValue: []}),
+  kafkaTopics: DS.attr({defaultValue: []})
 });

--- a/webapp/frontend/app/models/create-lambda-instance.js
+++ b/webapp/frontend/app/models/create-lambda-instance.js
@@ -13,5 +13,5 @@ export default DS.Model.extend({
   DiskSlave: DS.attr('number',  {defaultValue: 20}),
   ipAllocation: DS.attr('string',  {defaultValue: "master"}),
   publicKeyName: DS.attr({defaultValue: []}),
-  kafkaTopics: DS.attr({defaultValue: []})
+  kafkaTopics: DS.attr()
 });

--- a/webapp/frontend/app/templates/components/create-lambda-instance-form.hbs
+++ b/webapp/frontend/app/templates/components/create-lambda-instance-form.hbs
@@ -88,6 +88,11 @@
             </div> <!--row-->
             <div class="row">
               <div class="form-group col-sm-6">
+                <label for="kafka_topics" class="col-sm-6">Apache Kafka topics:</label>
+                <div class="col-sm-6">
+                  {{input type="text" value=kafkaTopics placeholder="e.g. name1,name2,name3" size="50" class="form-control" required="false"}}
+                  <span id="helpBlock" class="help-block">Names of Apache Kafka topics</span>
+                </div>  <!--class="col-sm-6"-->
               </div>
             </div><!--row-->
           </div><!--box-body-->

--- a/webapp/tests/test_celery_tasks.py
+++ b/webapp/tests/test_celery_tasks.py
@@ -572,7 +572,8 @@ class TestCeleryTasks(APITestCase):
             'disk_slave': 40,
             'ip_allocation': 'master',
             'network_request': 1,
-            'project_name': "lambda.grnet.gr"
+            'project_name': "lambda.grnet.gr",
+            'kafka_topics': ["input", "output", "stream_output", "batch_output"]
         }
         lambda_info = LambdaInfo(specs)
 
@@ -631,8 +632,9 @@ class TestCeleryTasks(APITestCase):
         mock_set_lambda_instance_status_central_vm.delay.\
             assert_any_call(self.AUTHENTICATION_TOKEN, None, LambdaInstance.HADOOP_INSTALLED, "")
 
-        mock_lambda_instance_manager_fokia.run_playbook.assert_any_call(mock_ansible_manager,
-                                                                        'kafka-install.yml')
+        mock_lambda_instance_manager_fokia.\
+            run_playbook.assert_any_call(mock_ansible_manager, 'kafka-install.yml', None,
+                                         {'topics': specs['kafka_topics']})
         mock_check_ansible_result.assert_any_call(mock_ansible_result)
         mock_set_lambda_instance_status_event.delay.\
             assert_any_call(instance_uuid=None, status=LambdaInstance.KAFKA_INSTALLED)
@@ -683,7 +685,8 @@ class TestCeleryTasks(APITestCase):
             'disk_slave': 40,
             'ip_allocation': 'master',
             'network_request': 1,
-            'project_name': "lambda.grnet.gr"
+            'project_name': "lambda.grnet.gr",
+            'kafka_topics': ["input", "output", "stream_output", "batch_output"]
         }
         lambda_info = LambdaInfo(specs)
 
@@ -757,7 +760,8 @@ class TestCeleryTasks(APITestCase):
             'disk_slave': 40,
             'ip_allocation': 'master',
             'network_request': 1,
-            'project_name': "lambda.grnet.gr"
+            'project_name': "lambda.grnet.gr",
+            'kafka_topics': ["input", "output", "stream_output", "batch_output"]
         }
         lambda_info = LambdaInfo(specs)
 
@@ -842,7 +846,8 @@ class TestCeleryTasks(APITestCase):
             'disk_slave': 40,
             'ip_allocation': 'master',
             'network_request': 1,
-            'project_name': "lambda.grnet.gr"
+            'project_name': "lambda.grnet.gr",
+            'kafka_topics': ["input", "output", "stream_output", "batch_output"]
         }
         lambda_info = LambdaInfo(specs)
 
@@ -938,7 +943,8 @@ class TestCeleryTasks(APITestCase):
             'disk_slave': 40,
             'ip_allocation': 'master',
             'network_request': 1,
-            'project_name': "lambda.grnet.gr"
+            'project_name': "lambda.grnet.gr",
+            'kafka_topics': ["input", "output", "stream_output", "batch_output"]
         }
         lambda_info = LambdaInfo(specs)
 
@@ -1043,7 +1049,8 @@ class TestCeleryTasks(APITestCase):
             'disk_slave': 40,
             'ip_allocation': 'master',
             'network_request': 1,
-            'project_name': "lambda.grnet.gr"
+            'project_name': "lambda.grnet.gr",
+            'kafka_topics': ["input", "output", "stream_output", "batch_output"]
         }
         lambda_info = LambdaInfo(specs)
 
@@ -1102,8 +1109,9 @@ class TestCeleryTasks(APITestCase):
         mock_set_lambda_instance_status_central_vm.delay.\
             assert_any_call(self.AUTHENTICATION_TOKEN, None, LambdaInstance.HADOOP_INSTALLED, "")
 
-        mock_lambda_instance_manager_fokia.run_playbook.assert_any_call(mock_ansible_manager,
-                                                                        'kafka-install.yml')
+        mock_lambda_instance_manager_fokia.\
+            run_playbook.assert_any_call(mock_ansible_manager, 'kafka-install.yml', None,
+                                         {'topics': specs['kafka_topics']})
         mock_check_ansible_result.assert_any_call(mock_ansible_result)
         mock_set_lambda_instance_status_event.delay.\
             assert_any_call(instance_uuid=None, status=LambdaInstance.KAFKA_FAILED,
@@ -1157,7 +1165,8 @@ class TestCeleryTasks(APITestCase):
             'disk_slave': 40,
             'ip_allocation': 'master',
             'network_request': 1,
-            'project_name': "lambda.grnet.gr"
+            'project_name': "lambda.grnet.gr",
+            'kafka_topics': ["input", "output", "stream_output", "batch_output"]
         }
         lambda_info = LambdaInfo(specs)
 
@@ -1216,8 +1225,9 @@ class TestCeleryTasks(APITestCase):
         mock_set_lambda_instance_status_central_vm.delay.\
             assert_any_call(self.AUTHENTICATION_TOKEN, None, LambdaInstance.HADOOP_INSTALLED, "")
 
-        mock_lambda_instance_manager_fokia.run_playbook.assert_any_call(mock_ansible_manager,
-                                                                        'kafka-install.yml')
+        mock_lambda_instance_manager_fokia.\
+            run_playbook.assert_any_call(mock_ansible_manager, 'kafka-install.yml', None,
+                                         {'topics': specs['kafka_topics']})
         mock_check_ansible_result.assert_any_call(mock_ansible_result)
         mock_set_lambda_instance_status_event.delay.\
             assert_any_call(instance_uuid=None, status=LambdaInstance.KAFKA_INSTALLED)

--- a/webapp/tests/test_lambda_instances.py
+++ b/webapp/tests/test_lambda_instances.py
@@ -45,7 +45,8 @@ class TestLambdaInstanceCreate(APITestCase):
                           'disk_slave': 20,
                           'slaves': 2,
                           'ip_allocation': "master",
-                          'public_key_name': ["key-1", "key-2"]}
+                          'public_key_name': ["key-1", "key-2"],
+                          'kafka_topics': ["input", "output", "stream_output", "batch_output"]}
 
     # Gather required fields.
     required_keys = ['project_name',


### PR DESCRIPTION
# Description

The user should be able to decide the names of the Apache Kafka topics to be created when a new Lambda Instance is created.
# Implementation

The user will be able to insert the topic names from the Lambda Instance Create web page. If the user doesn't enter any name, three default topics ("input", "stream-output", "batch-output") will be created.
# To-Do
1. ~~Refactor Web Pages~~
2. ~~Refactor tests~~
# Notes

This pull request should be merged after #170 has been merged.
