### PR TITLE
Replace 'value' with 'line' in lineinfile ansible tasks

### DIFF
--- a/ansible/roles/common/tasks/master.yml
+++ b/ansible/roles/common/tasks/master.yml
@@ -46,6 +46,6 @@
   - name: Set PATH environment variable for flink user
     lineinfile: destfile="/home/flink/.bashrc"
               regexp="^PATH"
-              value="PATH=$PATH:{{ flink_home }}/bin:{{ hadoop_home }}/bin"
+              line="PATH=$PATH:{{ flink_home }}/bin:{{ hadoop_home }}/bin"
               state=present
               insertafter=EOF

--- a/ansible/roles/flink-apps/tasks/start-batch.yml
+++ b/ansible/roles/flink-apps/tasks/start-batch.yml
@@ -3,7 +3,7 @@
   - name: Set jar file path for batch job
     lineinfile: destfile="/home/flink/run_batch_job.sh"
               regexp="^export"
-              value="export JARFILE={{ jarfile }}"
+              line="export JARFILE={{ jarfile }}"
               state=present
               insertafter="^export"
 

--- a/ansible/roles/flink-apps/tasks/start-streaming.yml
+++ b/ansible/roles/flink-apps/tasks/start-streaming.yml
@@ -3,7 +3,7 @@
   - name: Set jar file path for streaming job
     lineinfile: destfile="/home/flink/run_streaming_job.sh"
               regexp="^export"
-              value="export JARFILE={{ jarfile }}"
+              line="export JARFILE={{ jarfile }}"
               state=present
               insertafter="^export"
 


### PR DESCRIPTION
Replaced 'value' with 'line' in lineinfile ansible tasks, as it is not documented.
