### PR TITLE
LAM-207 Create self-signed certificate and serve services over HTTPS

### DIFF
--- a/central_service/ansible/roles/central-vm/tasks/apache-install.yml
+++ b/central_service/ansible/roles/central-vm/tasks/apache-install.yml
@@ -7,7 +7,10 @@
       - libapache2-mod-wsgi
 
   - name: Install apache ssl module
-    command: a2enmod ssl
+    apache2_module: name={{item}} state=present
+    with_items:
+      - ssl
+      - rewrite
     notify: restart_apache2
 
   - name: Create /etc/apache2/ssl directory

--- a/central_service/ansible/roles/central-vm/tasks/apache-install.yml
+++ b/central_service/ansible/roles/central-vm/tasks/apache-install.yml
@@ -6,9 +6,21 @@
       - apache2-dev
       - libapache2-mod-wsgi
 
-  - name: Get the hostname of the vm.
-    command: hostname
-    register: hostname
+  - name: Install apache ssl module
+    command: a2enmod ssl
+    notify: restart_apache2
+
+  - name: Create /etc/apache2/ssl directory
+    file: path=/etc/apache2/ssl state=directory owner=root group=root mode=0755
+
+  - name: Create self-signed certificate (to become deprecated)
+    command: openssl req -new -nodes -x509 -subj "/C=GR/O=GRNET S.A./OU=okeanos.grnet.gr/CN={{ ansible_hostname }}" -days 3650 -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -extensions v3_ca creates=/etc/apache2/ssl/server.crt
+
+  - name: Change permissions of private key
+    file: path=/etc/apache2/ssl/server.key mode=600 owner=root group=root
+
+  - name: Change permissions of certificate
+    file: path=/etc/apache2/ssl/server.crt mode=600 owner=root group=root
 
   - name: Copy Lambda sites-available configuration.
     template: src=central-service-backend.conf.j2 dest=/etc/apache2/sites-available/central-service-backend.conf

--- a/central_service/ansible/roles/central-vm/tasks/apache-install.yml
+++ b/central_service/ansible/roles/central-vm/tasks/apache-install.yml
@@ -11,7 +11,7 @@
     notify: restart_apache2
 
   - name: Create /etc/apache2/ssl directory
-    file: path=/etc/apache2/ssl state=directory owner=root group=root mode=0755
+    file: path=/etc/apache2/ssl state=directory owner=root group=root mode=0744
 
   - name: Create self-signed certificate (to become deprecated)
     command: openssl req -new -nodes -x509 -subj "/C=GR/O=GRNET S.A./OU=okeanos.grnet.gr/CN={{ ansible_hostname }}" -days 3650 -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -extensions v3_ca creates=/etc/apache2/ssl/server.crt

--- a/central_service/ansible/roles/central-vm/templates/central-service-backend.conf.j2
+++ b/central_service/ansible/roles/central-vm/templates/central-service-backend.conf.j2
@@ -1,4 +1,10 @@
 <VirtualHost *:80>
+  RewriteEngine On
+  RewriteCond %{HTTPS} !=on
+  RewriteRule ^/?(.*) https://%{SERVER_NAME}/$1 [R,L]
+</VirtualHost>
+
+<VirtualHost *:443>
 	# The ServerName directive sets the request scheme, hostname and port that
 	# the server uses to identify itself. This is used when creating
 	# redirection URLs. In the context of virtual hosts, the ServerName
@@ -7,13 +13,17 @@
 	# value is not decisive as it is used as a last resort host regardless.
 	# However, you must set it for any further virtual host explicitly.
 	#ServerName www.example.com
-	ServerName {{ hostname.stdout_lines | replace("[", "") | replace("u", "") | replace("'", "") | replace("]", "") }}.vm.okeanos.grnet.gr
+	ServerName {{ ansible_hostname }}.vm.okeanos.grnet.gr
 
 	#ServerAdmin webmaster@localhost
 	DocumentRoot {{ repository_download_path }}/okeanos-LoD/central_service/app/
 
 	WSGIScriptAlias / {{ repository_download_path }}/okeanos-LoD/central_service/app/app/wsgi.py
 	WSGIPassAuthorization On
+
+  SSLEngine ON
+  SSLCertificateFile /etc/apache2/ssl/server.crt
+  SSLCertificateKeyFile /etc/apache2/ssl/server.key
 
 	# Available loglevels: trace8, ..., trace1, debug, info, notice, warn,
 	# error, crit, alert, emerg.

--- a/central_service/ansible/roles/central-vm/templates/central-service-mkdocs.conf.j2
+++ b/central_service/ansible/roles/central-vm/templates/central-service-mkdocs.conf.j2
@@ -1,6 +1,14 @@
 Listen 8083
+Listen 8084
 
 <VirtualHost *:8083>
+        ServerName {{ ansible_hostname }}.vm.okeanos.grnet.gr
+        RewriteEngine On
+        RewriteCond %{HTTPS} !=on
+        RewriteRule ^/?(.*) https://%{SERVER_NAME}:8084/$1 [R,L]
+</VirtualHost>
+
+<VirtualHost *:8084>
         # The ServerName directive sets the request scheme, hostname and port that
         # the server uses to identify itself. This is used when creating
         # redirection URLs. In the context of virtual hosts, the ServerName
@@ -9,10 +17,14 @@ Listen 8083
         # value is not decisive as it is used as a last resort host regardless.
         # However, you must set it for any further virtual host explicitly.
         #ServerName www.example.com
-        ServerName {{ hostname.stdout_lines | replace("[", "") | replace("u", "") | replace("'", "") | replace("]", "") }}.vm.okeanos.grnet.gr:8083
+        ServerName {{ ansible_hostname }}.vm.okeanos.grnet.gr:8083
 
         #ServerAdmin webmaster@localhost
         DocumentRoot {{ repository_download_path }}/okeanos-LoD/central_service/app/api-doc/site
+
+        SSLEngine ON
+        SSLCertificateFile /etc/apache2/ssl/server.crt
+        SSLCertificateKeyFile /etc/apache2/ssl/server.key
 
         # Available loglevels: trace8, ..., trace1, debug, info, notice, warn,
         # error, crit, alert, emerg.

--- a/webapp/ansible/roles/ember/templates/environment.js.j2
+++ b/webapp/ansible/roles/ember/templates/environment.js.j2
@@ -22,10 +22,10 @@ module.exports = function(environment) {
     }
   };
 
-  ENV.host = "http://{{ hostname.stdout_lines | replace("[", "") | replace("u", "") | replace("'", "") | replace("]", "") }}.vm.okeanos.grnet.gr"
+  ENV.host = "https://{{ ansible_hostname }}.vm.okeanos.grnet.gr"
 
   ENV.contentSecurityPolicy = {
-    'connect-src': "'self' http://{{ hostname.stdout_lines | replace("[", "") | replace("u", "") | replace("'", "") | replace("]", "") }}.vm.okeanos.grnet.gr:80"
+    'connect-src': "'self' https://{{ ansible_hostname }}.vm.okeanos.grnet.gr:443"
   }
 
   ENV['ember-simple-auth'] = {

--- a/webapp/ansible/roles/service-vm/tasks/apache-install.yml
+++ b/webapp/ansible/roles/service-vm/tasks/apache-install.yml
@@ -6,9 +6,21 @@
       - apache2-dev
       - libapache2-mod-wsgi
 
-  - name: Get the hostname of the vm.
-    command: hostname
-    register: hostname
+  - name: Install apache ssl module
+    command: a2enmod ssl
+    notify: restart apache2
+
+  - name: Create /etc/apache2/ssl directory
+    file: path=/etc/apache2/ssl state=directory owner=root group=root mode=0755
+
+  - name: Create self-signed certificate
+    command: openssl req -new -nodes -x509 -subj "/C=GR/O=GRNET S.A./OU=okeanos.grnet.gr/CN={{ ansible_hostname }}.vm.okeanos.grnet.gr" -days 3650 -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -extensions v3_ca creates=/etc/apache2/ssl/server.crt
+
+  - name: Change permissions of private key
+    file: path=/etc/apache2/ssl/server.key mode=600 owner=root group=root
+
+  - name: Change permissions of certificate
+    file: path=/etc/apache2/ssl/server.crt mode=600 owner=root group=root
 
   - name: Copy Lambda sites-available backend configuration.
     template: src=lambda-service-backend.conf.j2 dest=/etc/apache2/sites-available/lambda-service-backend.conf

--- a/webapp/ansible/roles/service-vm/tasks/apache-install.yml
+++ b/webapp/ansible/roles/service-vm/tasks/apache-install.yml
@@ -7,7 +7,10 @@
       - libapache2-mod-wsgi
 
   - name: Install apache ssl module
-    command: a2enmod ssl
+    apache2_module: name={{item}} state=present
+    with_items:
+      - ssl
+      - rewrite
     notify: restart_apache2
 
   - name: Create /etc/apache2/ssl directory
@@ -42,11 +45,6 @@
 
   - name: Remove default sites-enabled.
     command: a2dissite 000-default.conf
-
-  - name: Activate Apache rewrite module.
-    apache2_module: name=rewrite state=present
-    notify:
-          - restart_apache2
 
   - name: Activate Apache headers module.
     apache2_module: name=headers state=present

--- a/webapp/ansible/roles/service-vm/tasks/apache-install.yml
+++ b/webapp/ansible/roles/service-vm/tasks/apache-install.yml
@@ -8,7 +8,7 @@
 
   - name: Install apache ssl module
     command: a2enmod ssl
-    notify: restart apache2
+    notify: restart_apache2
 
   - name: Create /etc/apache2/ssl directory
     file: path=/etc/apache2/ssl state=directory owner=root group=root mode=0755

--- a/webapp/ansible/roles/service-vm/tasks/apache-install.yml
+++ b/webapp/ansible/roles/service-vm/tasks/apache-install.yml
@@ -11,7 +11,7 @@
     notify: restart_apache2
 
   - name: Create /etc/apache2/ssl directory
-    file: path=/etc/apache2/ssl state=directory owner=root group=root mode=0755
+    file: path=/etc/apache2/ssl state=directory owner=root group=root mode=0744
 
   - name: Create self-signed certificate
     command: openssl req -new -nodes -x509 -subj "/C=GR/O=GRNET S.A./OU=okeanos.grnet.gr/CN={{ ansible_hostname }}.vm.okeanos.grnet.gr" -days 3650 -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -extensions v3_ca creates=/etc/apache2/ssl/server.crt

--- a/webapp/ansible/roles/service-vm/templates/lambda-service-backend.conf.j2
+++ b/webapp/ansible/roles/service-vm/templates/lambda-service-backend.conf.j2
@@ -1,58 +1,58 @@
 <VirtualHost *:80>
-  RewriteEngine On
-  RewriteCond %{HTTPS} !=on
-  RewriteRule ^/?(.*) https://%{SERVER_NAME}/$1 [R,L]
+    RewriteEngine On
+    RewriteCond %{HTTPS} !=on
+    RewriteRule ^/?(.*) https://%{SERVER_NAME}/$1 [R,L]
 </VirtualHost>
 
 <VirtualHost *:443>
-	# The ServerName directive sets the request scheme, hostname and port that
-	# the server uses to identify itself. This is used when creating
-	# redirection URLs. In the context of virtual hosts, the ServerName
-	# specifies what hostname must appear in the request's Host: header to
-	# match this virtual host. For the default virtual host (this file) this
-	# value is not decisive as it is used as a last resort host regardless.
-	# However, you must set it for any further virtual host explicitly.
-	#ServerName www.example.com
-	ServerName {{ ansible_hostname }}.vm.okeanos.grnet.gr
+  	# The ServerName directive sets the request scheme, hostname and port that
+  	# the server uses to identify itself. This is used when creating
+  	# redirection URLs. In the context of virtual hosts, the ServerName
+  	# specifies what hostname must appear in the request's Host: header to
+  	# match this virtual host. For the default virtual host (this file) this
+  	# value is not decisive as it is used as a last resort host regardless.
+  	# However, you must set it for any further virtual host explicitly.
+  	#ServerName www.example.com
+  	ServerName {{ ansible_hostname }}.vm.okeanos.grnet.gr
 
-	#ServerAdmin webmaster@localhost
-	DocumentRoot {{ repository_download_path }}/okeanos-LoD/webapp/
+  	#ServerAdmin webmaster@localhost
+  	DocumentRoot {{ repository_download_path }}/okeanos-LoD/webapp/
 
-	WSGIScriptAlias / {{ repository_download_path }}/okeanos-LoD/webapp/webapp/wsgi.py
-	WSGIPassAuthorization On
+  	WSGIScriptAlias / {{ repository_download_path }}/okeanos-LoD/webapp/webapp/wsgi.py
+  	WSGIPassAuthorization On
 
-	Header always set Access-Control-Allow-Origin: "https://{{ ansible_hostname }}.vm.okeanos.grnet.gr:4201"
-	Header always set Access-Control-Allow-Credentials: true
-	Header always set Access-Control-Allow-Methods: "GET, POST, DELETE, OPTIONS"
-	Header always set Access-Control-Allow-Headers "Authorization"
-	Header always add Access-Control-Allow-Headers "Content-Type"
+  	Header always set Access-Control-Allow-Origin: "https://{{ ansible_hostname }}.vm.okeanos.grnet.gr:4201"
+  	Header always set Access-Control-Allow-Credentials: true
+  	Header always set Access-Control-Allow-Methods: "GET, POST, DELETE, OPTIONS"
+  	Header always set Access-Control-Allow-Headers "Authorization"
+  	Header always add Access-Control-Allow-Headers "Content-Type"
 
-	RewriteEngine On
-	RewriteCond %{REQUEST_METHOD} OPTIONS
-	RewriteRule ^(.*)$ $1 [R=200,L]
+  	RewriteEngine On
+  	RewriteCond %{REQUEST_METHOD} OPTIONS
+  	RewriteRule ^(.*)$ $1 [R=200,L]
 
-  SSLEngine ON
-  SSLCertificateFile /etc/apache2/ssl/server.crt
-  SSLCertificateKeyFile /etc/apache2/ssl/server.key
+    SSLEngine ON
+    SSLCertificateFile /etc/apache2/ssl/server.crt
+    SSLCertificateKeyFile /etc/apache2/ssl/server.key
 
-	# Available loglevels: trace8, ..., trace1, debug, info, notice, warn,
-	# error, crit, alert, emerg.
-	# It is also possible to configure the loglevel for particular
-	# modules, e.g.
-	#LogLevel info ssl:warn
+  	# Available loglevels: trace8, ..., trace1, debug, info, notice, warn,
+  	# error, crit, alert, emerg.
+  	# It is also possible to configure the loglevel for particular
+  	# modules, e.g.
+  	#LogLevel info ssl:warn
 
-	ErrorLog ${APACHE_LOG_DIR}/error.log
-	CustomLog ${APACHE_LOG_DIR}/access.log combined
+  	ErrorLog ${APACHE_LOG_DIR}/error.log
+  	CustomLog ${APACHE_LOG_DIR}/access.log combined
 
-	#limit request body size to 500MB
-	LimitRequestBody 524288000
+  	#limit request body size to 500MB
+  	LimitRequestBody 524288000
 
-	# For most configuration files from conf-available/, which are
-	# enabled or disabled at a global level, it is possible to
-	# include a line for only one particular virtual host. For example the
-	# following line enables the CGI configuration for this host only
-	# after it has been globally disabled with "a2disconf".
-	#Include conf-available/serve-cgi-bin.conf
+  	# For most configuration files from conf-available/, which are
+  	# enabled or disabled at a global level, it is possible to
+  	# include a line for only one particular virtual host. For example the
+  	# following line enables the CGI configuration for this host only
+  	# after it has been globally disabled with "a2disconf".
+  	#Include conf-available/serve-cgi-bin.conf
 </VirtualHost>
 
 # vim: syntax=apache ts=4 sw=4 sts=4 sr noet

--- a/webapp/ansible/roles/service-vm/templates/lambda-service-backend.conf.j2
+++ b/webapp/ansible/roles/service-vm/templates/lambda-service-backend.conf.j2
@@ -1,4 +1,13 @@
+Listen 80
+Listen 443
+
 <VirtualHost *:80>
+        RewriteEngine On
+        RewriteCond %{HTTPS} !=on
+        RewriteRule ^/?(.*) https://%{SERVER_NAME}/$1 [R,L]
+</VirtualHost>
+
+<VirtualHost *:443>
 	# The ServerName directive sets the request scheme, hostname and port that
 	# the server uses to identify itself. This is used when creating
 	# redirection URLs. In the context of virtual hosts, the ServerName
@@ -7,7 +16,7 @@
 	# value is not decisive as it is used as a last resort host regardless.
 	# However, you must set it for any further virtual host explicitly.
 	#ServerName www.example.com
-	ServerName {{ hostname.stdout_lines | replace("[", "") | replace("u", "") | replace("'", "") | replace("]", "") }}.vm.okeanos.grnet.gr
+	ServerName {{ ansible_hostname }}.vm.okeanos.grnet.gr
 
 	#ServerAdmin webmaster@localhost
 	DocumentRoot {{ repository_download_path }}/okeanos-LoD/webapp/
@@ -15,7 +24,7 @@
 	WSGIScriptAlias / {{ repository_download_path }}/okeanos-LoD/webapp/webapp/wsgi.py
 	WSGIPassAuthorization On
 
-	Header always set Access-Control-Allow-Origin: "http://{{ hostname.stdout_lines | replace("[", "") | replace("u", "") | replace("'", "") | replace("]", "") }}.vm.okeanos.grnet.gr:4200"
+	Header always set Access-Control-Allow-Origin: "http://{{ ansible_hostname }}.vm.okeanos.grnet.gr:4200"
 	Header always set Access-Control-Allow-Credentials: true
 	Header always set Access-Control-Allow-Methods: "GET, POST, DELETE, OPTIONS"
 	Header always set Access-Control-Allow-Headers "Authorization"
@@ -24,6 +33,10 @@
 	RewriteEngine On
 	RewriteCond %{REQUEST_METHOD} OPTIONS
 	RewriteRule ^(.*)$ $1 [R=200,L]
+
+  SSLEngine ON
+  SSLCertificateFile /etc/apache2/ssl/server.crt
+  SSLCertificateKeyFile /etc/apache2/ssl/server.key
 
 	# Available loglevels: trace8, ..., trace1, debug, info, notice, warn,
 	# error, crit, alert, emerg.

--- a/webapp/ansible/roles/service-vm/templates/lambda-service-backend.conf.j2
+++ b/webapp/ansible/roles/service-vm/templates/lambda-service-backend.conf.j2
@@ -1,10 +1,7 @@
-Listen 80
-Listen 443
-
 <VirtualHost *:80>
-        RewriteEngine On
-        RewriteCond %{HTTPS} !=on
-        RewriteRule ^/?(.*) https://%{SERVER_NAME}/$1 [R,L]
+  RewriteEngine On
+  RewriteCond %{HTTPS} !=on
+  RewriteRule ^/?(.*) https://%{SERVER_NAME}/$1 [R,L]
 </VirtualHost>
 
 <VirtualHost *:443>

--- a/webapp/ansible/roles/service-vm/templates/lambda-service-backend.conf.j2
+++ b/webapp/ansible/roles/service-vm/templates/lambda-service-backend.conf.j2
@@ -24,7 +24,7 @@ Listen 443
 	WSGIScriptAlias / {{ repository_download_path }}/okeanos-LoD/webapp/webapp/wsgi.py
 	WSGIPassAuthorization On
 
-	Header always set Access-Control-Allow-Origin: "http://{{ ansible_hostname }}.vm.okeanos.grnet.gr:4200"
+	Header always set Access-Control-Allow-Origin: "https://{{ ansible_hostname }}.vm.okeanos.grnet.gr:4201"
 	Header always set Access-Control-Allow-Credentials: true
 	Header always set Access-Control-Allow-Methods: "GET, POST, DELETE, OPTIONS"
 	Header always set Access-Control-Allow-Headers "Authorization"

--- a/webapp/ansible/roles/service-vm/templates/lambda-service-frontend.conf.j2
+++ b/webapp/ansible/roles/service-vm/templates/lambda-service-frontend.conf.j2
@@ -1,6 +1,14 @@
 Listen 4200
+Listen 4201
 
 <VirtualHost *:4200>
+        ServerName {{ ansible_hostname }}.vm.okeanos.grnet.gr
+        RewriteEngine On
+        RewriteCond %{HTTPS} !=on
+        RewriteRule ^/?(.*) https://%{SERVER_NAME}:4201/$1 [R,L]
+</VirtualHost>
+
+<VirtualHost *:4201>
 
         <Directory /var/www/>
                 Options Indexes FollowSymLinks
@@ -16,10 +24,14 @@ Listen 4200
         # value is not decisive as it is used as a last resort host regardless.
         # However, you must set it for any further virtual host explicitly.
         #ServerName www.example.com
-        ServerName {{ hostname.stdout_lines | replace("[", "") | replace("u", "") | replace("'", "") | replace("]", "") }}.vm.okeanos.grnet.gr:4200
+        ServerName {{ ansible_hostname }}.vm.okeanos.grnet.gr:4200
 
         #ServerAdmin webmaster@localhost
         DocumentRoot {{ repository_download_path }}/okeanos-LoD/webapp/frontend/dist
+
+        SSLEngine ON
+        SSLCertificateFile /etc/apache2/ssl/server.crt
+        SSLCertificateKeyFile /etc/apache2/ssl/server.key
 
         # Available loglevels: trace8, ..., trace1, debug, info, notice, warn,
         # error, crit, alert, emerg.

--- a/webapp/ansible/roles/service-vm/templates/lambda-service-mkdocs.conf.j2
+++ b/webapp/ansible/roles/service-vm/templates/lambda-service-mkdocs.conf.j2
@@ -1,4 +1,5 @@
 Listen 8083
+Listen 8084
 
 <VirtualHost *:8083>
         ServerName {{ ansible_hostname }}.vm.okeanos.grnet.gr

--- a/webapp/ansible/roles/service-vm/templates/lambda-service-mkdocs.conf.j2
+++ b/webapp/ansible/roles/service-vm/templates/lambda-service-mkdocs.conf.j2
@@ -1,6 +1,13 @@
 Listen 8083
 
 <VirtualHost *:8083>
+        ServerName {{ ansible_hostname }}.vm.okeanos.grnet.gr
+        RewriteEngine On
+        RewriteCond %{HTTPS} !=on
+        RewriteRule ^/?(.*) https://%{SERVER_NAME}:8084/$1 [R,L]
+</VirtualHost>
+
+<VirtualHost *:8084>
         # The ServerName directive sets the request scheme, hostname and port that
         # the server uses to identify itself. This is used when creating
         # redirection URLs. In the context of virtual hosts, the ServerName
@@ -9,10 +16,14 @@ Listen 8083
         # value is not decisive as it is used as a last resort host regardless.
         # However, you must set it for any further virtual host explicitly.
         #ServerName www.example.com
-        ServerName {{ hostname.stdout_lines | replace("[", "") | replace("u", "") | replace("'", "") | replace("]", "") }}.vm.okeanos.grnet.gr:8083
+        ServerName {{ ansible_hostname }}.vm.okeanos.grnet.gr:8083
 
         #ServerAdmin webmaster@localhost
         DocumentRoot {{ repository_download_path }}/okeanos-LoD/webapp/api-doc/site
+
+        SSLEngine ON
+        SSLCertificateFile /etc/apache2/ssl/server.crt
+        SSLCertificateKeyFile /etc/apache2/ssl/server.key
 
         # Available loglevels: trace8, ..., trace1, debug, info, notice, warn,
         # error, crit, alert, emerg.

--- a/webapp/backend/central_vm_tasks.py
+++ b/webapp/backend/central_vm_tasks.py
@@ -19,7 +19,7 @@ def create_lambda_instance_central_vm(self, auth_token, instance_uuid, instance_
     # Make a POST request to send the information to Central VM. In case of a timeout, retry
     # three(3) times(default Celery retry) and then stop trying.
     try:
-        requests.post(url="http://" + settings.CENTRAL_VM_IP + "/api/lambda_instances/",
+        requests.post(url="https://" + settings.CENTRAL_VM_IP + "/api/lambda_instances/",
                       json={
                           'uuid': instance_uuid,
                           'name': instance_name,
@@ -47,7 +47,7 @@ def set_lambda_instance_status_central_vm(self, auth_token, instance_uuid, statu
     # Make a Post request to send the information to Central VM. In case of a timeout, retry
     # three(3) times(default Celery retry) and then stop trying.
     try:
-        requests.post(url=("http://" + settings.CENTRAL_VM_IP + "/api/lambda_instances/{}/status/").
+        requests.post(url=("https://" + settings.CENTRAL_VM_IP + "/api/lambda_instances/{}/status/").
                       format(instance_uuid), json={
             'status': status,
             'failure_message': failure_message
@@ -70,7 +70,7 @@ def delete_lambda_instance_central_vm(self, auth_token, instance_uuid):
     # Make a Delete request to Central VM. In case of a timeout, retry three(3)
     # times(default Celery retry) and then stop trying.
     try:
-        requests.delete(url=("http://" + settings.CENTRAL_VM_IP + "/api/lambda_instances/{}/").
+        requests.delete(url=("https://" + settings.CENTRAL_VM_IP + "/api/lambda_instances/{}/").
                         format(instance_uuid), headers={
             'Authorization': "Token {}".format(auth_token),
             'Content-Type': "application/json"
@@ -92,7 +92,7 @@ def create_application_central_vm(self, auth_token, application_uuid, name, desc
     # Make a Post request to send the information to Central VM. In case of a timeout, retry
     # three(3) times(default Celery retry) and then stop trying.
     try:
-        requests.post(url="http://" + settings.CENTRAL_VM_IP + "/api/lambda_applications/",
+        requests.post(url="https://" + settings.CENTRAL_VM_IP + "/api/lambda_applications/",
                       json={
                           'uuid': "{}".format(application_uuid),
                           'name': name,
@@ -122,7 +122,7 @@ def set_application_status_central_vm(self, auth_token, application_uuid, status
     # Make a Post request to send the information to Central VM. In case of a timeout, retry
     # three(3) times(default Celery retry) and then stop trying.
     try:
-        requests.post(url=("http://" + settings.CENTRAL_VM_IP +
+        requests.post(url=("https://" + settings.CENTRAL_VM_IP +
                            "/api/lambda_applications/{}/status/").format(application_uuid), json={
             'status': status,
             'failure_message': failure_message
@@ -145,7 +145,7 @@ def delete_application_central_vm(self, auth_token, application_uuid):
     # Make a Delete request to Central VM. In case of a timeout, retry three(3)
     # times(default Celery retry) and then stop trying.
     try:
-        requests.delete(url=("http://" + settings.CENTRAL_VM_IP + "/api/lambda_applications/{}/").
+        requests.delete(url=("https://" + settings.CENTRAL_VM_IP + "/api/lambda_applications/{}/").
                         format(application_uuid), headers={
             'Authorization': "Token {}".format(auth_token),
             'Content-Type': "application/json"

--- a/webapp/backend/central_vm_tasks.py
+++ b/webapp/backend/central_vm_tasks.py
@@ -19,7 +19,8 @@ def create_lambda_instance_central_vm(self, auth_token, instance_uuid, instance_
     # Make a POST request to send the information to Central VM. In case of a timeout, retry
     # three(3) times(default Celery retry) and then stop trying.
     try:
-        requests.post(url="https://" + settings.CENTRAL_VM_IP + "/api/lambda_instances/",
+        requests.post(verify=False,
+                      url="https://" + settings.CENTRAL_VM_IP + "/api/lambda_instances/",
                       json={
                           'uuid': instance_uuid,
                           'name': instance_name,
@@ -47,7 +48,8 @@ def set_lambda_instance_status_central_vm(self, auth_token, instance_uuid, statu
     # Make a Post request to send the information to Central VM. In case of a timeout, retry
     # three(3) times(default Celery retry) and then stop trying.
     try:
-        requests.post(url=("https://" + settings.CENTRAL_VM_IP + "/api/lambda_instances/{}/status/").
+        requests.post(verify=False,
+                      url=("https://" + settings.CENTRAL_VM_IP + "/api/lambda_instances/{}/status/").
                       format(instance_uuid), json={
             'status': status,
             'failure_message': failure_message
@@ -70,7 +72,8 @@ def delete_lambda_instance_central_vm(self, auth_token, instance_uuid):
     # Make a Delete request to Central VM. In case of a timeout, retry three(3)
     # times(default Celery retry) and then stop trying.
     try:
-        requests.delete(url=("https://" + settings.CENTRAL_VM_IP + "/api/lambda_instances/{}/").
+        requests.delete(verify=False,
+                        url=("https://" + settings.CENTRAL_VM_IP + "/api/lambda_instances/{}/").
                         format(instance_uuid), headers={
             'Authorization': "Token {}".format(auth_token),
             'Content-Type': "application/json"
@@ -92,7 +95,8 @@ def create_application_central_vm(self, auth_token, application_uuid, name, desc
     # Make a Post request to send the information to Central VM. In case of a timeout, retry
     # three(3) times(default Celery retry) and then stop trying.
     try:
-        requests.post(url="https://" + settings.CENTRAL_VM_IP + "/api/lambda_applications/",
+        requests.post(verify=False,
+                      url="https://" + settings.CENTRAL_VM_IP + "/api/lambda_applications/",
                       json={
                           'uuid': "{}".format(application_uuid),
                           'name': name,
@@ -122,7 +126,8 @@ def set_application_status_central_vm(self, auth_token, application_uuid, status
     # Make a Post request to send the information to Central VM. In case of a timeout, retry
     # three(3) times(default Celery retry) and then stop trying.
     try:
-        requests.post(url=("https://" + settings.CENTRAL_VM_IP +
+        requests.post(verify=False,
+                      url=("https://" + settings.CENTRAL_VM_IP +
                            "/api/lambda_applications/{}/status/").format(application_uuid), json={
             'status': status,
             'failure_message': failure_message
@@ -145,8 +150,9 @@ def delete_application_central_vm(self, auth_token, application_uuid):
     # Make a Delete request to Central VM. In case of a timeout, retry three(3)
     # times(default Celery retry) and then stop trying.
     try:
-        requests.delete(url=("https://" + settings.CENTRAL_VM_IP + "/api/lambda_applications/{}/").
-                        format(application_uuid), headers={
+        requests.delete(verify=False,
+                        url=("https://" + settings.CENTRAL_VM_IP + "/api/lambda_applications/{}/").
+                             format(application_uuid), headers={
             'Authorization': "Token {}".format(auth_token),
             'Content-Type': "application/json"
         })

--- a/webapp/backend/central_vm_tasks.py
+++ b/webapp/backend/central_vm_tasks.py
@@ -49,7 +49,8 @@ def set_lambda_instance_status_central_vm(self, auth_token, instance_uuid, statu
     # three(3) times(default Celery retry) and then stop trying.
     try:
         requests.post(verify=False,
-                      url=("https://" + settings.CENTRAL_VM_IP + "/api/lambda_instances/{}/status/").
+                      url=("https://" + settings.CENTRAL_VM_IP
+                           + "/api/lambda_instances/{}/status/").
                       format(instance_uuid), json={
             'status': status,
             'failure_message': failure_message

--- a/webapp/frontend/app/adapters/application.js
+++ b/webapp/frontend/app/adapters/application.js
@@ -3,7 +3,7 @@ import ENV from 'frontend/config/environment';
 import DataAdapterMixin from 'ember-simple-auth/mixins/data-adapter-mixin';
 
 export default DS.JSONAPIAdapter.extend(DataAdapterMixin, {
-  host: ENV.host + ':80',
+  host: ENV.host + ':443',
   namespace: 'api',
   headers: {
     'Accept': 'application/json',

--- a/webapp/frontend/app/adapters/upload-app.js
+++ b/webapp/frontend/app/adapters/upload-app.js
@@ -2,6 +2,6 @@ import DS from "ember-data";
 import ENV from 'frontend/config/environment';
 
 export default DS.JSONAPIAdapter.extend({
-  host: ENV.host + ':80',
+  host: ENV.host + ':443',
   namespace: 'api/apps/',
  });

--- a/webapp/frontend/app/authenticators/django.js
+++ b/webapp/frontend/app/authenticators/django.js
@@ -14,7 +14,7 @@ export default Base.extend({
   },
 
   authenticate: function(token) {
-    let host = ENV.host + ':80',
+    let host = ENV.host + ':443',
       namespace = 'api/authenticate',
       authUrl = [ host, namespace ].join('/');
     return new Ember.RSVP.Promise((resolve, reject) => {

--- a/webapp/frontend/render_ember_environment.py
+++ b/webapp/frontend/render_ember_environment.py
@@ -5,8 +5,8 @@ import os
 if __name__ == '__main__':
     env = Environment(loader=FileSystemLoader('../ansible/roles/ember/templates'))
     template = env.get_template('environment.js.j2')
-    hostname = {'stdout_lines': socket.gethostname()}
-    settings = template.render(hostname=hostname)
+    ansible_hostname = socket.gethostname()
+    settings = template.render(ansible_hostname=ansible_hostname)
     if not os.path.exists('config'):
         os.mkdir('config')
     with open('config/environment.js', 'w') as f:

--- a/webapp/tests/test_celery_central_vm_tasks.py
+++ b/webapp/tests/test_celery_central_vm_tasks.py
@@ -50,7 +50,8 @@ class TestCeleryCentralVMTasks(APITestCase):
 
         # Assert that the proper mock calls have been made.
         mock_requests.post.assert_called_with(
-            url="http://CENTRAL_VM_IP/api/lambda_instances/",
+            verify=False,
+            url="https://CENTRAL_VM_IP/api/lambda_instances/",
             json={
                 'uuid': instance_uuid,
                 'name': instance_name,
@@ -89,7 +90,8 @@ class TestCeleryCentralVMTasks(APITestCase):
 
         # Assert that the proper mock calls have been made.
         mock_requests.post.assert_called_with(
-            url="http://CENTRAL_VM_IP/api/lambda_instances/",
+            verify=False,
+            url="https://CENTRAL_VM_IP/api/lambda_instances/",
             json={
                 'uuid': instance_uuid,
                 'name': instance_name,
@@ -132,7 +134,8 @@ class TestCeleryCentralVMTasks(APITestCase):
 
         # Assert that the proper mock calls have been made.
         mock_requests.post.assert_called_with(
-            url="http://CENTRAL_VM_IP/api/lambda_instances/",
+            verify=False,
+            url="https://CENTRAL_VM_IP/api/lambda_instances/",
             json={
                 'uuid': instance_uuid,
                 'name': instance_name,
@@ -167,7 +170,8 @@ class TestCeleryCentralVMTasks(APITestCase):
 
         # Assert that the proper mock calls have been made.
         mock_requests.post.assert_called_with(
-            url="http://CENTRAL_VM_IP/api/lambda_instances/{}/status/".format(instance_uuid),
+            verify=False,
+            url="https://CENTRAL_VM_IP/api/lambda_instances/{}/status/".format(instance_uuid),
             json={
                 'status': status,
                 'failure_message': failure_message
@@ -205,7 +209,8 @@ class TestCeleryCentralVMTasks(APITestCase):
 
         # Assert that the proper mock calls have been made.
         mock_requests.post.assert_called_with(
-            url="http://CENTRAL_VM_IP/api/lambda_instances/{}/status/".format(instance_uuid),
+            verify=False,
+            url="https://CENTRAL_VM_IP/api/lambda_instances/{}/status/".format(instance_uuid),
             json={
                 'status': status,
                 'failure_message': failure_message
@@ -247,7 +252,8 @@ class TestCeleryCentralVMTasks(APITestCase):
 
         # Assert that the proper mock calls have been made.
         mock_requests.post.assert_called_with(
-            url="http://CENTRAL_VM_IP/api/lambda_instances/{}/status/".format(instance_uuid),
+            verify=False,
+            url="https://CENTRAL_VM_IP/api/lambda_instances/{}/status/".format(instance_uuid),
             json={
                 'status': status,
                 'failure_message': failure_message
@@ -276,7 +282,8 @@ class TestCeleryCentralVMTasks(APITestCase):
 
         # Assert that the proper mock calls have been made.
         mock_requests.delete.assert_called_with(
-            url="http://CENTRAL_VM_IP/api/lambda_instances/{}/".format(instance_uuid),
+            verify=False,
+            url="https://CENTRAL_VM_IP/api/lambda_instances/{}/".format(instance_uuid),
             headers={
                 'Authorization': "Token {}".format(self.AUTHENTICATION_TOKEN),
                 'Content-Type': "application/json"
@@ -307,7 +314,8 @@ class TestCeleryCentralVMTasks(APITestCase):
 
         # Assert that the proper mock calls have been made.
         mock_requests.delete.assert_called_with(
-            url="http://CENTRAL_VM_IP/api/lambda_instances/{}/".format(instance_uuid),
+            verify=False,
+            url="https://CENTRAL_VM_IP/api/lambda_instances/{}/".format(instance_uuid),
             headers={
                 'Authorization': "Token {}".format(self.AUTHENTICATION_TOKEN),
                 'Content-Type': "application/json"
@@ -342,7 +350,8 @@ class TestCeleryCentralVMTasks(APITestCase):
 
         # Assert that the proper mock calls have been made.
         mock_requests.delete.assert_called_with(
-            url="http://CENTRAL_VM_IP/api/lambda_instances/{}/".format(instance_uuid),
+            verify=False,
+            url="https://CENTRAL_VM_IP/api/lambda_instances/{}/".format(instance_uuid),
             headers={
                 'Authorization': "Token {}".format(self.AUTHENTICATION_TOKEN),
                 'Content-Type': "application/json"
@@ -370,7 +379,8 @@ class TestCeleryCentralVMTasks(APITestCase):
 
         # Assert that the proper mock calls have been made.
         mock_requests.post.assert_called_with(
-            url="http://CENTRAL_VM_IP/api/lambda_applications/",
+            verify=False,
+            url="https://CENTRAL_VM_IP/api/lambda_applications/",
             json={
                 'uuid': "{}".format(application_uuid),
                 'name': application_name,
@@ -410,7 +420,8 @@ class TestCeleryCentralVMTasks(APITestCase):
 
         # Assert that the proper mock calls have been made.
         mock_requests.post.assert_called_with(
-            url="http://CENTRAL_VM_IP/api/lambda_applications/",
+            verify=False,
+            url="https://CENTRAL_VM_IP/api/lambda_applications/",
             json={
                 'uuid': "{}".format(application_uuid),
                 'name': application_name,
@@ -455,7 +466,8 @@ class TestCeleryCentralVMTasks(APITestCase):
 
         # Assert that the proper mock calls have been made.
         mock_requests.post.assert_called_with(
-            url="http://CENTRAL_VM_IP/api/lambda_applications/",
+            verify=False,
+            url="https://CENTRAL_VM_IP/api/lambda_applications/",
             json={
                 'uuid': "{}".format(application_uuid),
                 'name': application_name,
@@ -490,7 +502,8 @@ class TestCeleryCentralVMTasks(APITestCase):
 
         # Assert that the proper mock calls have been made.
         mock_requests.post.assert_called_with(
-            url="http://CENTRAL_VM_IP/api/lambda_applications/{}/status/".format(application_uuid),
+            verify=False,
+            url="https://CENTRAL_VM_IP/api/lambda_applications/{}/status/".format(application_uuid),
             json={
                 'status': status,
                 'failure_message': "failure_message"
@@ -528,7 +541,8 @@ class TestCeleryCentralVMTasks(APITestCase):
 
         # Assert that the proper mock calls have been made.
         mock_requests.post.assert_called_with(
-            url="http://CENTRAL_VM_IP/api/lambda_applications/{}/status/".format(application_uuid),
+            verify=False,
+            url="https://CENTRAL_VM_IP/api/lambda_applications/{}/status/".format(application_uuid),
             json={
                 'status': status,
                 'failure_message': "failure_message"
@@ -570,7 +584,8 @@ class TestCeleryCentralVMTasks(APITestCase):
 
         # Assert that the proper mock calls have been made.
         mock_requests.post.assert_called_with(
-            url="http://CENTRAL_VM_IP/api/lambda_applications/{}/status/".format(application_uuid),
+            verify=False,
+            url="https://CENTRAL_VM_IP/api/lambda_applications/{}/status/".format(application_uuid),
             json={
                 'status': status,
                 'failure_message': "failure_message"
@@ -599,7 +614,8 @@ class TestCeleryCentralVMTasks(APITestCase):
 
         # Assert that the proper mock calls have been made.
         mock_requests.delete.assert_called_with(
-            url="http://CENTRAL_VM_IP/api/lambda_applications/{}/".format(application_uuid),
+            verify=False,
+            url="https://CENTRAL_VM_IP/api/lambda_applications/{}/".format(application_uuid),
             headers={
                 'Authorization': "Token {}".format(self.AUTHENTICATION_TOKEN),
                 'Content-Type': "application/json"
@@ -629,7 +645,8 @@ class TestCeleryCentralVMTasks(APITestCase):
 
         # Assert that the proper mock calls have been made.
         mock_requests.delete.assert_called_with(
-            url="http://CENTRAL_VM_IP/api/lambda_instances/{}/".format(instance_uuid),
+            verify=False,
+            url="https://CENTRAL_VM_IP/api/lambda_instances/{}/".format(instance_uuid),
             headers={
                 'Authorization': "Token {}".format(self.AUTHENTICATION_TOKEN),
                 'Content-Type': "application/json"
@@ -664,7 +681,8 @@ class TestCeleryCentralVMTasks(APITestCase):
 
         # Assert that the proper mock calls have been made.
         mock_requests.delete.assert_called_with(
-            url="http://CENTRAL_VM_IP/api/lambda_applications/{}/".format(application_uuid),
+            verify=False,
+            url="https://CENTRAL_VM_IP/api/lambda_applications/{}/".format(application_uuid),
             headers={
                 'Authorization': "Token {}".format(self.AUTHENTICATION_TOKEN),
                 'Content-Type': "application/json"


### PR DESCRIPTION
## Description
### Central service
- API backend (Django)
- API documentation
### Service VM
- Ember application
- API backend (Django)
- API documentation

are now served over https with a self-signed certificate.
