### PR TITLE
[LAM-211] Display names instead of IDs

### DIFF
--- a/webapp/ansible/roles/ember/vars/main.yml
+++ b/webapp/ansible/roles/ember/vars/main.yml
@@ -5,3 +5,4 @@ ember_addons:
       - ember-simple-auth
       - ember-data-filter
       - ember-cli-pagination
+      - ember-tooltips

--- a/webapp/frontend/app/templates/lambda-app.hbs
+++ b/webapp/frontend/app/templates/lambda-app.hbs
@@ -137,7 +137,7 @@
                                   <table class="table">
                                       <thead>
                                       <tr>
-                                          <th>Instance ID</th>
+                                          <th>Instance Name</th>
                                           <th>App started</th>
                                           <th>Actions</th>
                                       </tr>
@@ -145,7 +145,11 @@
                                       <tbody>
                                       {{#each model.instances as |li|}}
                                           <tr>
-                                              <td>{{li.id}} </td>
+                                              <td>
+                                                {{#link-to 'lambda-instance' li.id tooltipContent=li.id}}
+                                                  {{li.name}}
+                                                {{/link-to}}
+                                              </td>
                                               <td>{{li.started_app}}</td>
                                               <td>
                                                 <div class="table">

--- a/webapp/frontend/app/templates/lambda-apps/index.hbs
+++ b/webapp/frontend/app/templates/lambda-apps/index.hbs
@@ -64,7 +64,6 @@
           <table  class="table table-bordered table-hover table-responsive">
             <thead>
               <tr>
-                <th>#id</th>
                 <th>Name</th>
                 <th>Status</th>
                 <th>Type</th>
@@ -85,8 +84,11 @@
               </tr> -->
               {{#each pagedContent as |lambda-application|}}
               <tr>
-                <td>{{lambda-application.id}}</td>
-                <td>{{lambda-application.name}}</td>
+                <td>
+                  {{#link-to 'lambda-app' lambda-application.id tooltipContent=lambda-application.id}}
+                    {{lambda-application.name}}
+                  {{/link-to}}
+                </td>
                 <td><span>{{lambda-application.status_detail}}</span></td>
                 <td>{{lower-case lambda-application.app_type}}</td>
                 <td>

--- a/webapp/frontend/app/templates/lambda-instance.hbs
+++ b/webapp/frontend/app/templates/lambda-instance.hbs
@@ -164,7 +164,7 @@
     <div class="col-xs-12">
       <div class="box box-warning">
         <div class="box-header with-border">
-          <h3 class="box-title"><i class="fa fa-th"></i> Applications uploaded to this Lambda Instance</h3>
+          <h3 class="box-title"><i class="fa fa-th"></i> Applications deployed on this Lambda Instance</h3>
         </div><!-- /.box-header -->
         <div class="box-body">
           <div class=“row”>
@@ -177,7 +177,7 @@
               <table class="table table-bordered table-hover table-responsive">
                 <thead>
                   <tr>
-                    <th>ID</th>
+                    <th>Name</th>
                     <th>Type</th>
                     <th>Started</th>
                     <th> Actions </th>
@@ -186,7 +186,11 @@
                 <tbody>
                   {{#each model.apps as |application|}}
                   <tr class="instance-info">
-                    <td>{{application.id}}</td>
+                    <td>
+                      {{#link-to 'lambda-app' application.id tooltipContent=application.id}}
+                        {{application.name}}
+                      {{/link-to}}
+                    </td>
                     <td>{{lower-case application.app_type}}</td>
                     <td>{{application.started}}</td>
                     <td>

--- a/webapp/frontend/app/templates/lambda-instances/index.hbs
+++ b/webapp/frontend/app/templates/lambda-instances/index.hbs
@@ -76,7 +76,6 @@
                   <table  class="table table-bordered table-hover table-responsive">
                     <thead>
                       <tr>
-                        <th>#id</th>
                         <th>Name</th>
                         <th>Status</th>
                         <th>Actions</th>
@@ -96,8 +95,11 @@
                       </tr> -->
                       {{#each pagedContent as |lambda-instance|}}
                       <tr>
-                        <td>{{lambda-instance.id}}</td>
-                        <td>{{lambda-instance.name}}</td>
+                        <td>
+                          {{#link-to 'lambda-instance' lambda-instance.id tooltipContent=lambda-instance.id}}
+                            {{lambda-instance.name}}
+                          {{/link-to}}
+                        </td>
                         <td><span>{{lambda-instance.status_detail}}</span></td>
                         <td>
                           <table class="table">


### PR DESCRIPTION
- [x] Display names of lambda instances and applications instead of IDs
- [x] Show IDs in tooltips
- [x] Link to instance/application details
