### PR TITLE
Corrections in project quotas in user_okeanos_projects API call

### DIFF
--- a/core/fokia/utils.py
+++ b/core/fokia/utils.py
@@ -242,21 +242,68 @@ def get_user_okeanos_projects(auth_url, auth_token):
 
         quotas = astakos_client.get_quotas()
 
-        available_cpus = quotas[project_id]['cyclades.cpu']['project_limit'] -\
-                         quotas[project_id]['cyclades.cpu']['project_usage']
-        available_disk = quotas[project_id]['cyclades.disk']['project_limit'] -\
-                         quotas[project_id]['cyclades.disk']['project_usage']
-        available_floating_ips = quotas[project_id]['cyclades.floating_ip']['project_limit'] -\
-                                 quotas[project_id]['cyclades.floating_ip']['project_usage']
-        available_private_networks = quotas[project_id]['cyclades.network.private'][
-                                         'project_limit'] - quotas[project_id][
-                                             'cyclades.network.private']['project_usage']
-        available_ram = quotas[project_id]['cyclades.ram']['project_limit'] -\
-                        quotas[project_id]['cyclades.ram']['project_usage']
-        available_vms = quotas[project_id]['cyclades.vm']['project_limit'] -\
-                        quotas[project_id]['cyclades.vm']['project_usage']
-        available_pithos_disk_space = quotas[project_id]['pithos.diskspace']['project_limit'] -\
-                                      quotas[project_id]['pithos.diskspace']['project_usage']
+        project_available_cpus = quotas[project_id]['cyclades.cpu']['project_limit'] -\
+                                 quotas[project_id]['cyclades.cpu']['project_usage']
+        project_available_disk = quotas[project_id]['cyclades.disk']['project_limit'] -\
+                                 quotas[project_id]['cyclades.disk']['project_usage']
+        project_available_floating_ips = quotas[project_id]['cyclades.floating_ip']['project_limit']\
+                                         -\
+                                         quotas[project_id]['cyclades.floating_ip']['project_usage']
+        project_available_private_networks = quotas[project_id]['cyclades.network.private'][
+                                                 'project_limit'] -\
+                                             quotas[project_id]['cyclades.network.private'][
+                                                 'project_usage']
+        project_available_ram = quotas[project_id]['cyclades.ram']['project_limit'] -\
+                                quotas[project_id]['cyclades.ram']['project_usage']
+        project_available_vms = quotas[project_id]['cyclades.vm']['project_limit'] -\
+                                quotas[project_id]['cyclades.vm']['project_usage']
+        project_available_pithos_disk_space = quotas[project_id]['pithos.diskspace'][
+                                                  'project_limit'] -\
+                                              quotas[project_id]['pithos.diskspace'][
+                                                  'project_usage']
+
+        user_available_cpus = quotas[project_id]['cyclades.cpu']['limit'] -\
+                              quotas[project_id]['cyclades.cpu']['usage']
+        user_available_disk = quotas[project_id]['cyclades.disk']['limit'] -\
+                              quotas[project_id]['cyclades.disk']['usage']
+        user_available_floating_ips = quotas[project_id]['cyclades.floating_ip']['limit'] -\
+                                      quotas[project_id]['cyclades.floating_ip']['usage']
+        user_available_private_networks = quotas[project_id]['cyclades.network.private']['limit'] -\
+                                          quotas[project_id]['cyclades.network.private']['usage']
+        user_available_ram = quotas[project_id]['cyclades.ram']['limit'] -\
+                             quotas[project_id]['cyclades.ram']['usage']
+        user_available_vms = quotas[project_id]['cyclades.vm']['limit'] -\
+                             quotas[project_id]['cyclades.vm']['usage']
+        user_available_pithos_disk_space = quotas[project_id]['pithos.diskspace']['limit'] -\
+                                           quotas[project_id]['pithos.diskspace']['usage']
+
+        available_cpus = user_available_cpus
+        if user_available_cpus > project_available_cpus:
+            available_cpus = project_available_cpus
+
+        available_disk = user_available_disk
+        if user_available_disk > project_available_disk:
+            available_disk = project_available_disk
+
+        available_floating_ips = user_available_floating_ips
+        if user_available_floating_ips > project_available_floating_ips:
+            available_floating_ips = project_available_floating_ips
+
+        available_private_networks = user_available_private_networks
+        if user_available_private_networks > project_available_private_networks:
+            available_private_networks = project_available_private_networks
+
+        available_ram = user_available_ram
+        if user_available_ram > project_available_ram:
+            available_ram = project_available_ram
+
+        available_vms = user_available_vms
+        if user_available_vms > project_available_vms:
+            available_vms = project_available_vms
+
+        available_pithos_disk_space = user_available_pithos_disk_space
+        if user_available_pithos_disk_space > project_available_pithos_disk_space:
+            available_pithos_disk_space = project_available_pithos_disk_space
 
         okeanos_projects.append({
             'id': project_id,

--- a/core/tests/test_utils.py
+++ b/core/tests/test_utils.py
@@ -32,60 +32,60 @@ def test_get_user_okeanos_projects(mock_AstakosClient):
                 u'usage': 0
             },
             u'cyclades.cpu': {
-                u'limit': 112,
-                u'pending': 0,
-                u'project_limit': 112,
-                u'project_pending': 0,
-                u'project_usage': 74,
-                u'usage': 24
-            },
-            u'cyclades.disk': {
-                u'limit': 1073741824000,
-                u'pending': 0,
-                u'project_limit': 200,
-                u'project_pending': 0,
-                u'project_usage': 150,
-                u'usage': 171798691840
-            },
-            u'cyclades.floating_ip': {
-                u'limit': 26,
-                u'pending': 0,
-                u'project_limit': 26,
-                u'project_pending': 0,
-                u'project_usage': 26,
-                u'usage': 5
-            },
-            u'cyclades.network.private': {
                 u'limit': 20,
-                u'pending': 0,
-                u'project_limit': 20,
-                u'project_pending': 0,
-                u'project_usage': 12,
-                u'usage': 1
-            },
-            u'cyclades.ram': {
-                u'limit': 163208757248,
-                u'pending': 0,
-                u'project_limit': 500,
-                u'project_pending': 0,
-                u'project_usage': 360,
-                u'usage': 25769803776
-            },
-            u'cyclades.vm': {
-                u'limit': 28,
-                u'pending': 0,
-                u'project_limit': 28,
-                u'project_pending': 0,
-                u'project_usage': 21,
-                u'usage': 6
-            },
-            u'pithos.diskspace': {
-                u'limit': 107374182400,
                 u'pending': 0,
                 u'project_limit': 100,
                 u'project_pending': 0,
-                u'project_usage': 60,
-                u'usage': 228849836
+                u'project_usage': 95,
+                u'usage': 4
+            },
+            u'cyclades.disk': {
+                u'limit': 200,
+                u'pending': 0,
+                u'project_limit': 1000,
+                u'project_pending': 0,
+                u'project_usage': 150,
+                u'usage': 150
+            },
+            u'cyclades.floating_ip': {
+                u'limit': 5,
+                u'pending': 0,
+                u'project_limit': 30,
+                u'project_pending': 0,
+                u'project_usage': 26,
+                u'usage': 4
+            },
+            u'cyclades.network.private': {
+                u'limit': 50,
+                u'pending': 0,
+                u'project_limit': 50,
+                u'project_pending': 0,
+                u'project_usage': 40,
+                u'usage': 49
+            },
+            u'cyclades.ram': {
+                u'limit': 100,
+                u'pending': 0,
+                u'project_limit': 1000,
+                u'project_pending': 0,
+                u'project_usage': 400,
+                u'usage': 50
+            },
+            u'cyclades.vm': {
+                u'limit': 1000,
+                u'pending': 0,
+                u'project_limit': 10000,
+                u'project_pending': 0,
+                u'project_usage': 9999,
+                u'usage': 0
+            },
+            u'pithos.diskspace': {
+                u'limit': 1000,
+                u'pending': 0,
+                u'project_limit': 1000,
+                u'project_pending': 0,
+                u'project_usage': 50,
+                u'usage': 0
             }
         },
         '2': {
@@ -98,60 +98,60 @@ def test_get_user_okeanos_projects(mock_AstakosClient):
                 u'usage': 0
             },
             u'cyclades.cpu': {
-                u'limit': 112,
+                u'limit': 1,
                 u'pending': 0,
-                u'project_limit': 112,
+                u'project_limit': 100,
                 u'project_pending': 0,
-                u'project_usage': 74,
-                u'usage': 24
-            },
-            u'cyclades.disk': {
-                u'limit': 1073741824000,
-                u'pending': 0,
-                u'project_limit': 600,
-                u'project_pending': 0,
-                u'project_usage': 320,
-                u'usage': 171798691840
-            },
-            u'cyclades.floating_ip': {
-                u'limit': 26,
-                u'pending': 0,
-                u'project_limit': 26,
-                u'project_pending': 0,
-                u'project_usage': 26,
-                u'usage': 5
-            },
-            u'cyclades.network.private': {
-                u'limit': 20,
-                u'pending': 0,
-                u'project_limit': 20,
-                u'project_pending': 0,
-                u'project_usage': 12,
+                u'project_usage': 75,
                 u'usage': 1
             },
+            u'cyclades.disk': {
+                u'limit': 200,
+                u'pending': 0,
+                u'project_limit': 200,
+                u'project_pending': 0,
+                u'project_usage': 200,
+                u'usage': 10
+            },
+            u'cyclades.floating_ip': {
+                u'limit': 0,
+                u'pending': 0,
+                u'project_limit': 100,
+                u'project_pending': 0,
+                u'project_usage': 25,
+                u'usage': 0
+            },
+            u'cyclades.network.private': {
+                u'limit': 100,
+                u'pending': 0,
+                u'project_limit': 100,
+                u'project_pending': 0,
+                u'project_usage': 100,
+                u'usage': 0
+            },
             u'cyclades.ram': {
-                u'limit': 163208757248,
+                u'limit': 0,
                 u'pending': 0,
                 u'project_limit': 500,
                 u'project_pending': 0,
-                u'project_usage': 500,
-                u'usage': 25769803776
+                u'project_usage': 0,
+                u'usage': 0
             },
             u'cyclades.vm': {
-                u'limit': 28,
+                u'limit': 100,
                 u'pending': 0,
-                u'project_limit': 28,
+                u'project_limit': 100,
                 u'project_pending': 0,
-                u'project_usage': 21,
-                u'usage': 6
+                u'project_usage': 20,
+                u'usage': 21
             },
             u'pithos.diskspace': {
-                u'limit': 107374182400,
+                u'limit': 0,
                 u'pending': 0,
-                u'project_limit': 440,
+                u'project_limit': 0,
                 u'project_pending': 0,
-                u'project_usage': 40,
-                u'usage': 228849836
+                u'project_usage': 0,
+                u'usage': 0
             }
         },
     }
@@ -170,24 +170,24 @@ def test_get_user_okeanos_projects(mock_AstakosClient):
         {
             'id': '1',
             'name': "name1",
-            'vm': 7,
-            'cpu': 38,
-            'ram': 140,
+            'vm': 1,
+            'cpu': 5,
+            'ram': 50,
             'disk': 50,
-            'floating_ip': 0,
-            'private_network': 8,
-            'pithos_space': 40
+            'floating_ip': 1,
+            'private_network': 1,
+            'pithos_space': 950
         },
         {
             'id': '2',
             'name': "name2",
-            'vm': 7,
-            'cpu': 38,
+            'vm': 79,
+            'cpu': 0,
             'ram': 0,
-            'disk': 280,
+            'disk': 0,
             'floating_ip': 0,
-            'private_network': 8,
-            'pithos_space': 400
+            'private_network': 0,
+            'pithos_space': 0
         }]
 
 


### PR DESCRIPTION
# Description

This pull requests refers to the calculation of remaining quotas for each project of the user. The first implementation would return the remaining quotas for each project, without taking in account the fact that the user might not have rights to use all of them.
# Solution

The call now checks the quotas that the user can use, compares them to the remaining quotas of the project and returns the smallest of the two which is the actual quotas that the user can use from each project.
