### PR TITLE
Make fokia accept user provided arguments in case of direct usage.

### DIFF
--- a/core/fokia/lambda_instance_manager.py
+++ b/core/fokia/lambda_instance_manager.py
@@ -149,28 +149,33 @@ def lambda_instance_destroy(instance_uuid, auth_token,
 
 
 if __name__ == "__main__":
-    # parser = argparse.ArgumentParser(description="Okeanos VM provisioning")
-    # parser.add_argument('--cloud', type=str, dest="cloud", default="lambda")
-    # parser.add_argument('--project-name', type=str, dest="project_name",
-    #                     default="lambda.grnet.gr")
-    #
-    # parser.add_argument('--slaves', type=int, dest='slaves', default=2)
-    # parser.add_argument('--vcpus_master', type=int, dest='vcpus_master', default=4)
-    # parser.add_argument('--vcpus_slave', type=int, dest='vcpus_slave', default=4)
-    # parser.add_argument('--ram_master', type=int, dest='ram_master', default=4096)  # in MB
-    # parser.add_argument('--ram_slave', type=int, dest='ram_slave', default=4096)  # in MB
-    # parser.add_argument('--disk_master', type=int, dest='disk_master', default=40)  # in GB
-    # parser.add_argument('--disk_slave', type=int, dest='disk_slave', default=40)  # in GB
-    # parser.add_argument('--ip_allocation', type=str, dest='ip_allocation', default="master",
-    #                     help="Choose between none, master, all")
-    # parser.add_argument('--network_request', type=int, dest='network_request', default=1)
-    # parser.add_argument('--image_name', type=str, dest='image_name', default='debian')
-    # parser.add_argument('--action', type=str, dest='action', default='create')
-    # parser.add_argument('--cluster_id', type=int, dest='cluster_id', default=0)
-    #
-    # args = parser.parse_args()
 
+    import argparse
     import uuid
+
+    parser = argparse.ArgumentParser(description="Okeanos VM provisioning")
+    parser.add_argument('--master-name', type=str, dest="master_name",
+                        default="lambda-master",
+                        help="Name of Flink master VM [default: lambda-master]")
+    parser.add_argument('--slaves', type=int, dest='slaves', default=1,
+                        help="Number of Flink slaves [default: 1]")
+    parser.add_argument('--vcpus_master', type=int, dest='vcpus_master', default=4,
+                        help="Number of CPUs on Flink master [default: 4]")
+    parser.add_argument('--vcpus_slave', type=int, dest='vcpus_slave', default=4,
+                        help="Number of CPUs on Flink slave(s) [default: 4]")
+    parser.add_argument('--ram_master', type=int, dest='ram_master', default=4096,
+                        help="Size of RAM on Flink master (in MB) [default: 4096MB]")
+    parser.add_argument('--ram_slave', type=int, dest='ram_slave', default=4096,
+                        help="Size of RAM on Flink slave(s) (in MB) [default: 4096MB]")
+    parser.add_argument('--disk_master', type=int, dest='disk_master', default=40,
+                        help="Size of disk on Flink master (in GB) [default: 40GB]")
+    parser.add_argument('--disk_slave', type=int, dest='disk_slave', default=40,
+                        help="Size of disk on Flink slave(s) (in GB) [default: 40GB]")
+    parser.add_argument('--project-name', type=str, dest="project_name",
+                        default="lambda.grnet.gr",
+                        help="~okeanos Project [default: lambda.grnet.gr]")
+
+    args = parser.parse_args()
 
     keys_folder = expanduser('~/.ssh/lambda_instances/')
     if not os.path.exists(keys_folder):
@@ -179,7 +184,16 @@ if __name__ == "__main__":
                            " (Y/n)?".format(keys_folder))
         if choice.lower() in ["", "y", "yes"]:
             os.mkdir(keys_folder, 0o755)
-    ansible_manager, provisioner_response = create_cluster(cluster_id=uuid.uuid4())
+
+    ansible_manager, provisioner_response = create_cluster(cluster_id=uuid.uuid4(),
+                                                           master_name=args.master_name,
+                                                           slaves=args.slaves,
+                                                           vcpus_master=args.vcpus_master,
+                                                           vcpus_slave=args.vcpus_slave,
+                                                           ram_master=args.ram_master,
+                                                           ram_slave=args.ram_slave,
+                                                           disk_master=args.disk_master,
+                                                           project_name=args.project_name)
     run_playbook(ansible_manager, 'initialize.yml')
     run_playbook(ansible_manager, 'common-install.yml')
     run_playbook(ansible_manager, 'hadoop-install.yml')

--- a/core/fokia/lambda_instance_manager.py
+++ b/core/fokia/lambda_instance_manager.py
@@ -172,8 +172,8 @@ if __name__ == "__main__":
     parser.add_argument('--disk_slave', type=int, dest='disk_slave', default=40,
                         help="Size of disk on Flink slave(s) (in GB) [default: 40GB]")
     parser.add_argument('--project-name', type=str, dest="project_name",
-                        default="lambda.grnet.gr",
-                        help="~okeanos Project [default: lambda.grnet.gr]")
+                        default="project.grnet.gr",
+                        help="~okeanos Project [default: project.grnet.gr]")
 
     args = parser.parse_args()
 

--- a/core/fokia/lambda_instance_manager.py
+++ b/core/fokia/lambda_instance_manager.py
@@ -193,6 +193,7 @@ if __name__ == "__main__":
                                                            ram_master=args.ram_master,
                                                            ram_slave=args.ram_slave,
                                                            disk_master=args.disk_master,
+                                                           disk_slave=args.disk_slave,
                                                            project_name=args.project_name)
     run_playbook(ansible_manager, 'initialize.yml')
     run_playbook(ansible_manager, 'common-install.yml')


### PR DESCRIPTION
# Description

The proposed modification allows the Fokia CLI user to define in a custom way (via command line arguments) the specifications of the to-be-provisioned lambda instance. 
# Implementation

Added import of `argparse` library within main section and allow the definition of command line arguments which can be used in order to define specifications for the provisioned VMs. An additional help section within each argument helps when the user calls the wrapper using the `-h` or the `--help` arguments. E.g.:

```
$ python lambda_instance_manager.py --help
usage: lambda_instance_manager.py [-h] [--master-name MASTER_NAME]
                                  [--slaves SLAVES]
                                  [--vcpus_master VCPUS_MASTER]
                                  [--vcpus_slave VCPUS_SLAVE]
                                  [--ram_master RAM_MASTER]
                                  [--ram_slave RAM_SLAVE]
                                  [--disk_master DISK_MASTER]
                                  [--disk_slave DISK_SLAVE]
                                  [--project-name PROJECT_NAME]

Okeanos VM provisioning

optional arguments:
  -h, --help            show this help message and exit
  --master-name MASTER_NAME
                        Name of Flink master VM [default: lambda-master]
  --slaves SLAVES       Number of Flink slaves [default: 1]
  --vcpus_master VCPUS_MASTER
                        Number of CPUs on Flink master [default: 4]
  --vcpus_slave VCPUS_SLAVE
                        Number of CPUs on Flink slave(s) [default: 4]
  --ram_master RAM_MASTER
                        Size of RAM on Flink master (in MB) [default: 4096MB]
  --ram_slave RAM_SLAVE
                        Size of RAM on Flink slave(s) (in MB) [default:
                        4096MB]
  --disk_master DISK_MASTER
                        Size of disk on Flink master (in GB) [default: 40GB]
  --disk_slave DISK_SLAVE
                        Size of disk on Flink slave(s) (in GB) [default: 40GB]
  --project-name PROJECT_NAME
                        ~okeanos Project [default: lambda.grnet.gr]
```

please review /cc @gouzouni625 @ioantsaf 
