### PR TITLE
Corrections on CI scripts after https verification was installed

### DIFF
--- a/CI/manage_application.py
+++ b/CI/manage_application.py
@@ -37,7 +37,7 @@ class ApplicationManager:
 
         # Send a request to the service vm to upload the application.
         with open(self.application, 'r') as application_file:
-            response = requests.post("http://{ip}/api/apps/".format(ip=self.service_vm_ip),
+            response = requests.post("https://{ip}/api/apps/".format(ip=self.service_vm_ip),
                                      headers={'Authorization': "Token {token}".
                                      format(token=self.authentication_token)},
                                      files={'file': application_file},
@@ -54,13 +54,13 @@ class ApplicationManager:
         application_uuid = response_json['data'][0]['id']
 
         # Wait until the entry of the application on the API database has been created.
-        applications = requests.get("http://{ip}/api/apps/".format(ip=self.service_vm_ip),
+        applications = requests.get("https://{ip}/api/apps/".format(ip=self.service_vm_ip),
                                     headers={'Authorization': "Token {token}".
                                              format(token=self.authentication_token)},
                                     verify=False)
         while len(applications.json()['data']) == 0 and max_wait > 0:
             time.sleep(sleep_time)
-            applications = requests.get("http://{ip}/api/apps/".format(ip=self.service_vm_ip),
+            applications = requests.get("https://{ip}/api/apps/".format(ip=self.service_vm_ip),
                                         headers={'Authorization': "Token {token}".
                                                  format(token=self.authentication_token)},
                                         verify=False)
@@ -78,7 +78,7 @@ class ApplicationManager:
         """
 
         # Get the uuid of the lambda instance.
-        lambda_instances = requests.get("http://{ip}/api/lambda-instances/".
+        lambda_instances = requests.get("https://{ip}/api/lambda-instances/".
                                         format(ip=self.service_vm_ip),
                                         headers={'Authorization': "Token {token}".
                                                  format(token=self.authentication_token)},
@@ -86,14 +86,14 @@ class ApplicationManager:
         lambda_instance_uuid = lambda_instances.json()['data'][0]['id']
 
         # Get the uuid of the application.
-        applications = requests.get("http://{ip}/api/apps/".format(ip=self.service_vm_ip),
+        applications = requests.get("https://{ip}/api/apps/".format(ip=self.service_vm_ip),
                                     headers={'Authorization': "Token {token}".
                                              format(token=self.authentication_token)},
                                     verify=False)
         application_uuid = applications.json()['data'][0]['id']
 
         # Send a request to the service vm to deploy the application.
-        requests.post("http://{ip}/api/apps/{application_id}/deploy/".
+        requests.post("https://{ip}/api/apps/{application_id}/deploy/".
                       format(ip=self.service_vm_ip, application_id=application_uuid),
                       headers={'Authorization': "Token {token}".
                                format(token=self.authentication_token)},
@@ -101,14 +101,14 @@ class ApplicationManager:
                       verify=False)
 
         # Wait for the application to be deployed.
-        application_details = requests.get("http://{ip}/api/apps/{id}/".
+        application_details = requests.get("https://{ip}/api/apps/{id}/".
                                            format(ip=self.service_vm_ip, id=application_uuid),
                                            headers={'Authorization': "Token {token}".
                                                     format(token=self.authentication_token)},
                                            verify=False)
         while len(application_details.json()['data'][0]['lambda_instances']) == 0 and max_wait > 0:
             time.sleep(sleep_time)
-            application_details = requests.get("http://{ip}/api/apps/{id}/".
+            application_details = requests.get("https://{ip}/api/apps/{id}/".
                                                format(ip=self.service_vm_ip, id=application_uuid),
                                                headers={'Authorization': "Token {token}".
                                                         format(token=self.authentication_token)},
@@ -124,7 +124,7 @@ class ApplicationManager:
         """
 
         # Get the uuid of the lambda instance.
-        lambda_instances = requests.get("http://{ip}/api/lambda-instances/".
+        lambda_instances = requests.get("https://{ip}/api/lambda-instances/".
                                         format(ip=self.service_vm_ip),
                                         headers={'Authorization': "Token {token}".
                                                  format(token=self.authentication_token)},
@@ -132,14 +132,14 @@ class ApplicationManager:
         lambda_instance_uuid = lambda_instances.json()['data'][0]['id']
 
         # Get the uuid of the application.
-        applications = requests.get("http://{ip}/api/apps/".format(ip=self.service_vm_ip),
+        applications = requests.get("https://{ip}/api/apps/".format(ip=self.service_vm_ip),
                                     headers={'Authorization': "Token {token}".
                                              format(token=self.authentication_token)},
                                     verify=False)
         application_uuid = applications.json()['data'][0]['id']
 
         # Send a request to the service vm to start the application.
-        requests.post("http://{ip}/api/apps/{application_id}/start/".
+        requests.post("https://{ip}/api/apps/{application_id}/start/".
                       format(ip=self.service_vm_ip, application_id=application_uuid),
                       headers={'Authorization': "Token {token}".
                                format(token=self.authentication_token)},
@@ -147,7 +147,7 @@ class ApplicationManager:
                       verify=False)
 
         # Wait for the application to be started.
-        application_details = requests.get("http://{ip}/api/apps/{id}/".
+        application_details = requests.get("https://{ip}/api/apps/{id}/".
                                            format(ip=self.service_vm_ip, id=application_uuid),
                                            headers={'Authorization': "Token {token}".
                                                     format(token=self.authentication_token)},
@@ -155,7 +155,7 @@ class ApplicationManager:
         while (not application_details.json()['data'][0]['lambda_instances'][0]['started'])\
                 and (max_wait > 0):
             time.sleep(sleep_time)
-            application_details = requests.get("http://{ip}/api/apps/{id}/".
+            application_details = requests.get("https://{ip}/api/apps/{id}/".
                                                format(ip=self.service_vm_ip, id=application_uuid),
                                                headers={'Authorization': "Token {token}".
                                                         format(token=self.authentication_token)},
@@ -174,7 +174,7 @@ class ApplicationManager:
                          state.
         """
 
-        application_details = requests.get("http://{ip}/api/apps/{id}/".
+        application_details = requests.get("https://{ip}/api/apps/{id}/".
                                            format(ip=self.service_vm_ip, id=application_uuid),
                                            headers={'Authorization': "Token {token}".
                                                     format(token=self.authentication_token)},
@@ -185,7 +185,7 @@ class ApplicationManager:
 
         while application_status != status and max_wait > 0:
             time.sleep(sleep_time)
-            application_details = requests.get("http://{ip}/api/apps/{id}/".
+            application_details = requests.get("https://{ip}/api/apps/{id}/".
                                                format(ip=self.service_vm_ip, id=application_uuid),
                                                headers={'Authorization': "Token {token}".
                                                         format(token=self.authentication_token)},

--- a/CI/manage_application.py
+++ b/CI/manage_application.py
@@ -43,7 +43,8 @@ class ApplicationManager:
                                      files={'file': application_file},
                                      data={'description': "Stream Word Count",
                                            'project_name': "lambda.grnet.gr",
-                                           'type': "streaming"})
+                                           'type': "streaming"},
+                                     verify=False)
 
         # Print the response for logging purposes.
         response_json = response.json()
@@ -55,12 +56,14 @@ class ApplicationManager:
         # Wait until the entry of the application on the API database has been created.
         applications = requests.get("http://{ip}/api/apps/".format(ip=self.service_vm_ip),
                                     headers={'Authorization': "Token {token}".
-                                             format(token=self.authentication_token)})
+                                             format(token=self.authentication_token)},
+                                    verify=False)
         while len(applications.json()['data']) == 0 and max_wait > 0:
             time.sleep(sleep_time)
             applications = requests.get("http://{ip}/api/apps/".format(ip=self.service_vm_ip),
                                         headers={'Authorization': "Token {token}".
-                                                 format(token=self.authentication_token)})
+                                                 format(token=self.authentication_token)},
+                                        verify=False)
             max_wait -= 1
 
         # Wait for the application to be uploaded.
@@ -78,13 +81,15 @@ class ApplicationManager:
         lambda_instances = requests.get("http://{ip}/api/lambda-instances/".
                                         format(ip=self.service_vm_ip),
                                         headers={'Authorization': "Token {token}".
-                                                 format(token=self.authentication_token)})
+                                                 format(token=self.authentication_token)},
+                                        verify=False)
         lambda_instance_uuid = lambda_instances.json()['data'][0]['id']
 
         # Get the uuid of the application.
         applications = requests.get("http://{ip}/api/apps/".format(ip=self.service_vm_ip),
                                     headers={'Authorization': "Token {token}".
-                                             format(token=self.authentication_token)})
+                                             format(token=self.authentication_token)},
+                                    verify=False)
         application_uuid = applications.json()['data'][0]['id']
 
         # Send a request to the service vm to deploy the application.
@@ -92,19 +97,22 @@ class ApplicationManager:
                       format(ip=self.service_vm_ip, application_id=application_uuid),
                       headers={'Authorization': "Token {token}".
                                format(token=self.authentication_token)},
-                      json={'lambda_instance_id': lambda_instance_uuid})
+                      json={'lambda_instance_id': lambda_instance_uuid},
+                      verify=False)
 
         # Wait for the application to be deployed.
         application_details = requests.get("http://{ip}/api/apps/{id}/".
                                            format(ip=self.service_vm_ip, id=application_uuid),
                                            headers={'Authorization': "Token {token}".
-                                                    format(token=self.authentication_token)})
+                                                    format(token=self.authentication_token)},
+                                           verify=False)
         while len(application_details.json()['data'][0]['lambda_instances']) == 0 and max_wait > 0:
             time.sleep(sleep_time)
             application_details = requests.get("http://{ip}/api/apps/{id}/".
                                                format(ip=self.service_vm_ip, id=application_uuid),
                                                headers={'Authorization': "Token {token}".
-                                                        format(token=self.authentication_token)})
+                                                        format(token=self.authentication_token)},
+                                               verify=False)
             max_wait -= 1
 
     def start(self, sleep_time=10, max_wait=6):
@@ -119,13 +127,15 @@ class ApplicationManager:
         lambda_instances = requests.get("http://{ip}/api/lambda-instances/".
                                         format(ip=self.service_vm_ip),
                                         headers={'Authorization': "Token {token}".
-                                                 format(token=self.authentication_token)})
+                                                 format(token=self.authentication_token)},
+                                        verify=False)
         lambda_instance_uuid = lambda_instances.json()['data'][0]['id']
 
         # Get the uuid of the application.
         applications = requests.get("http://{ip}/api/apps/".format(ip=self.service_vm_ip),
                                     headers={'Authorization': "Token {token}".
-                                             format(token=self.authentication_token)})
+                                             format(token=self.authentication_token)},
+                                    verify=False)
         application_uuid = applications.json()['data'][0]['id']
 
         # Send a request to the service vm to start the application.
@@ -133,20 +143,23 @@ class ApplicationManager:
                       format(ip=self.service_vm_ip, application_id=application_uuid),
                       headers={'Authorization': "Token {token}".
                                format(token=self.authentication_token)},
-                      json={'lambda_instance_id': lambda_instance_uuid})
+                      json={'lambda_instance_id': lambda_instance_uuid},
+                      verify=False)
 
         # Wait for the application to be started.
         application_details = requests.get("http://{ip}/api/apps/{id}/".
                                            format(ip=self.service_vm_ip, id=application_uuid),
                                            headers={'Authorization': "Token {token}".
-                                                    format(token=self.authentication_token)})
+                                                    format(token=self.authentication_token)},
+                                           verify=False)
         while (not application_details.json()['data'][0]['lambda_instances'][0]['started'])\
                 and (max_wait > 0):
             time.sleep(sleep_time)
             application_details = requests.get("http://{ip}/api/apps/{id}/".
                                                format(ip=self.service_vm_ip, id=application_uuid),
                                                headers={'Authorization': "Token {token}".
-                                                        format(token=self.authentication_token)})
+                                                        format(token=self.authentication_token)},
+                                               verify=False)
             max_wait -= 1
 
     def _wait_for_application_status(self, status, application_uuid, sleep_time=60, max_wait=5):
@@ -164,7 +177,8 @@ class ApplicationManager:
         application_details = requests.get("http://{ip}/api/apps/{id}/".
                                            format(ip=self.service_vm_ip, id=application_uuid),
                                            headers={'Authorization': "Token {token}".
-                                                    format(token=self.authentication_token)})
+                                                    format(token=self.authentication_token)},
+                                           verify=False)
         application_status = application_details.json()['data'][0]['status']['message']
         pprint("Application status is {application_status}. Waiting...".
                format(application_status=application_status))
@@ -174,7 +188,8 @@ class ApplicationManager:
             application_details = requests.get("http://{ip}/api/apps/{id}/".
                                                format(ip=self.service_vm_ip, id=application_uuid),
                                                headers={'Authorization': "Token {token}".
-                                                        format(token=self.authentication_token)})
+                                                        format(token=self.authentication_token)},
+                                               verify=False)
             application_status = application_details.json()['data'][0]['status']['message']
             pprint("Application status is {application_status}. Waiting...".
                    format(application_status=application_status))

--- a/CI/manage_lambda_instance.py
+++ b/CI/manage_lambda_instance.py
@@ -51,7 +51,8 @@ class LambdaInstanceManager:
                                  headers={'Content-Type': 'application/json',
                                           'Authorization': "Token {token}".
                                  format(token=self.authentication_token)},
-                                 json=self.lambda_instance_information)
+                                 json=self.lambda_instance_information,
+                                 verify=False)
 
         # Print the response for logging purposes.
         response_json = response.json()
@@ -64,13 +65,14 @@ class LambdaInstanceManager:
         lambda_instances = requests.get("http://{ip}/api/lambda-instances/".
                                         format(ip=self.service_vm_ip),
                                         headers={'Authorization': "Token {token}".
-                                                 format(token=self.authentication_token)})
+                                                 format(token=self.authentication_token)},
+                                        verify=False)
         while len(lambda_instances.json()['data']) == 0 and max_wait > 0:
             time.sleep(sleep_time)
             lambda_instances = requests.\
                 get("http://{ip}/api/lambda-instances/".format(ip=self.service_vm_ip),
                     headers={'Authorization': "Token {token}".
-                    format(token=self.authentication_token)})
+                    format(token=self.authentication_token)}, verify=False)
             max_wait -= 1
 
         # Wait for the lambda instance to be created and started.
@@ -84,14 +86,15 @@ class LambdaInstanceManager:
         lambda_instances = requests.get("http://{ip}/api/lambda-instances/".
                                         format(ip=self.service_vm_ip),
                                         headers={'Authorization': "Token {token}".
-                                                 format(token=self.authentication_token)})
+                                                 format(token=self.authentication_token)},
+                                        verify=False)
         lambda_instance_uuid = lambda_instances.json()['data'][0]['id']
 
         # Send a request to the service vm to destroy the lambda instance.
         requests.delete("http://{ip}/api/lambda-instances/{id}/".
                         format(ip=self.service_vm_ip, id=lambda_instance_uuid),
                         headers={'Authorization': "Token {token}".
-                                 format(token=self.authentication_token)})
+                                 format(token=self.authentication_token)}, verify=False)
 
         # Wait for the lambda instance to be destroyed.
         self._wait_for_lambda_instance_status("DESTROYED", lambda_instance_uuid, 60, 5)
@@ -113,7 +116,8 @@ class LambdaInstanceManager:
                                                format(ip=self.service_vm_ip,
                                                       id=lambda_instance_uuid),
                                                headers={'Authorization': "Token {token}".
-                                                        format(token=self.authentication_token)})
+                                                        format(token=self.authentication_token)},
+                                               verify=False)
         lambda_instance_status = lambda_instance_details.json()['data'][0]['status']['message']
         pprint("Lambda Instance status is {lambda_instance_status}. Waiting...".
                format(lambda_instance_status=lambda_instance_status))
@@ -125,7 +129,8 @@ class LambdaInstanceManager:
                                                           id=lambda_instance_uuid),
                                                    headers={'Authorization': "Token {token}".
                                                             format(token=self.
-                                                                   authentication_token)})
+                                                                   authentication_token)},
+                                                   verify=False)
             lambda_instance_status = lambda_instance_details.json()['data'][0]['status']['message']
             pprint("Lambda Instance status is {lambda_instance_status}. Waiting...".
                    format(lambda_instance_status=lambda_instance_status))

--- a/CI/manage_lambda_instance.py
+++ b/CI/manage_lambda_instance.py
@@ -47,7 +47,7 @@ class LambdaInstanceManager:
         """
 
         # Send a request to the service vm to create a lambda instance.
-        response = requests.post("http://{ip}/api/lambda-instance/".format(ip=self.service_vm_ip),
+        response = requests.post("https://{ip}/api/lambda-instance/".format(ip=self.service_vm_ip),
                                  headers={'Content-Type': 'application/json',
                                           'Authorization': "Token {token}".
                                  format(token=self.authentication_token)},
@@ -62,7 +62,7 @@ class LambdaInstanceManager:
         lambda_instance_uuid = response_json['data'][0]['id']
 
         # Wait until the entry of the lambda instance on the API database has been created.
-        lambda_instances = requests.get("http://{ip}/api/lambda-instances/".
+        lambda_instances = requests.get("https://{ip}/api/lambda-instances/".
                                         format(ip=self.service_vm_ip),
                                         headers={'Authorization': "Token {token}".
                                                  format(token=self.authentication_token)},
@@ -70,7 +70,7 @@ class LambdaInstanceManager:
         while len(lambda_instances.json()['data']) == 0 and max_wait > 0:
             time.sleep(sleep_time)
             lambda_instances = requests.\
-                get("http://{ip}/api/lambda-instances/".format(ip=self.service_vm_ip),
+                get("https://{ip}/api/lambda-instances/".format(ip=self.service_vm_ip),
                     headers={'Authorization': "Token {token}".
                     format(token=self.authentication_token)}, verify=False)
             max_wait -= 1
@@ -83,7 +83,7 @@ class LambdaInstanceManager:
         Method for destroying a Lambda Instance.
         """
 
-        lambda_instances = requests.get("http://{ip}/api/lambda-instances/".
+        lambda_instances = requests.get("https://{ip}/api/lambda-instances/".
                                         format(ip=self.service_vm_ip),
                                         headers={'Authorization': "Token {token}".
                                                  format(token=self.authentication_token)},
@@ -91,7 +91,7 @@ class LambdaInstanceManager:
         lambda_instance_uuid = lambda_instances.json()['data'][0]['id']
 
         # Send a request to the service vm to destroy the lambda instance.
-        requests.delete("http://{ip}/api/lambda-instances/{id}/".
+        requests.delete("https://{ip}/api/lambda-instances/{id}/".
                         format(ip=self.service_vm_ip, id=lambda_instance_uuid),
                         headers={'Authorization': "Token {token}".
                                  format(token=self.authentication_token)}, verify=False)
@@ -112,7 +112,7 @@ class LambdaInstanceManager:
                          state.
         """
 
-        lambda_instance_details = requests.get("http://{ip}/api/lambda-instances/{id}/".
+        lambda_instance_details = requests.get("https://{ip}/api/lambda-instances/{id}/".
                                                format(ip=self.service_vm_ip,
                                                       id=lambda_instance_uuid),
                                                headers={'Authorization': "Token {token}".
@@ -124,7 +124,7 @@ class LambdaInstanceManager:
 
         while lambda_instance_status != status and max_wait > 0:
             time.sleep(sleep_time)
-            lambda_instance_details = requests.get("http://{ip}/api/lambda-instances/{id}/".
+            lambda_instance_details = requests.get("https://{ip}/api/lambda-instances/{id}/".
                                                    format(ip=self.service_vm_ip,
                                                           id=lambda_instance_uuid),
                                                    headers={'Authorization': "Token {token}".


### PR DESCRIPTION
# Description

After https verification was installed to the API, every call from CI scripts should ignore verification.
