### PR TITLE
Apache Flume

### DIFF
--- a/ansible/playbooks/flume-install.yml
+++ b/ansible/playbooks/flume-install.yml
@@ -1,0 +1,6 @@
+---
+
+- hosts: master
+  user: root
+  roles:
+    - apache-flume

--- a/ansible/roles/apache-flume/tasks/main.yml
+++ b/ansible/roles/apache-flume/tasks/main.yml
@@ -1,0 +1,6 @@
+---
+  - name: Include tasks for master.
+    include: master.yml
+    when: "'master' in group_names"
+    tags:
+      - master-install

--- a/ansible/roles/apache-flume/tasks/master.yml
+++ b/ansible/roles/apache-flume/tasks/master.yml
@@ -1,0 +1,16 @@
+---
+  - name: Download Apache Flume.
+    get_url: url="{{ mirror_url }}/{{ version }}/apache-flume-{{ version }}-bin.tar.gz" dest="{{ download_path }}/apache-flume-{{ version }}-bin.tar.gz"
+    environment: proxy_env
+
+  - name: Uncompress Apache Flume.
+    unarchive: src="{{ download_path }}/apache-flume-{{ version }}-bin.tar.gz" dest="{{ installation_path }}" copy=no owner=flume group=lambda
+
+  - name: Create softlink for Apache Flume.
+    file: src="{{ installation_path }}/apache-flume-{{ version }}-bin" dest="{{ installation_path }}/flume" state=link
+
+  - name: Configure Apache Flume.
+    template: src=flume-conf.properties.j2 dest="{{ installation_path }}/flume/conf/flume-conf.properties" owner=flume group=lambda mode=0644
+
+  - name: Start Apache Flume.
+    supervisorctl: name=apache_flume state=started

--- a/ansible/roles/apache-flume/tasks/master.yml
+++ b/ansible/roles/apache-flume/tasks/master.yml
@@ -4,7 +4,10 @@
     environment: proxy_env
 
   - name: Uncompress Apache Flume.
-    unarchive: src="{{ download_path }}/apache-flume-{{ version }}-bin.tar.gz" dest="{{ installation_path }}" copy=no owner=flume group=lambda
+    unarchive: src="{{ download_path }}/apache-flume-{{ version }}-bin.tar.gz" dest="{{ installation_path }}" copy=no
+
+  - name: Make sure the directory has the right owner and group.
+    file: path="{{ installation_path }}/apache-flume-{{ version }}-bin" owner=flume group=lambda
 
   - name: Create softlink for Apache Flume.
     file: src="{{ installation_path }}/apache-flume-{{ version }}-bin" dest="{{ installation_path }}/flume" state=link

--- a/ansible/roles/apache-flume/templates/flume-conf.properties.j2
+++ b/ansible/roles/apache-flume/templates/flume-conf.properties.j2
@@ -1,0 +1,38 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+agent.sources = {% for topic in vars["topics"] %} {{ topic }}Source {% endfor %}
+agent.channels = {% for topic in vars["topics"] %} {{ topic }}Channel {% endfor %}
+agent.sinks = {% for topic in vars["topics"] %} {{ topic }}Sink {% endfor %}
+
+{% for topic in vars["topics"] %}
+
+agent.sources.{{ topic }}Source.type = org.apache.flume.source.kafka.KafkaSource
+agent.sources.{{ topic }}Source.zookeeperConnect = master:2181
+agent.sources.{{ topic }}Source.topic = {{ topic }}
+agent.sources.{{ topic }}Source.groupId = flume
+agent.sources.{{ topic }}Source.kafka.consumer.timeout.ms = 100
+agent.sources.{{ topic }}Source.channel = {{ topic }}Channel
+
+agent.channels.{{ topic }}Channel.type = memory
+
+agent.sinks.{{ topic }}Sink.type = hdfs
+agent.sinks.{{ topic }}Sink.hdfs.path = /user/flume/{{ topic }}
+agent.sinks.{{ topic }}Sink.hdfs.fileType = DataStream
+agent.sinks.{{ topic }}Sink.channel = {{ topic }}Channel
+
+{% endfor %}

--- a/ansible/roles/apache-flume/templates/flume-conf.properties.j2
+++ b/ansible/roles/apache-flume/templates/flume-conf.properties.j2
@@ -31,6 +31,8 @@ agent.sources.{{ topic }}Source.kafka.consumer.timeout.ms = 100
 agent.sources.{{ topic }}Source.channels = {{ topic }}Channel
 
 agent.channels.{{ topic }}Channel.type = memory
+agent.channels.{{ topic }}Channel.capacity = 1000000
+agent.channels.{{ topic }}Channel.transactionCapacity = 100000
 
 agent.sinks.{{ topic }}Sink.type = hdfs
 agent.sinks.{{ topic }}Sink.hdfs.path = /user/flume/{{ topic }}

--- a/ansible/roles/apache-flume/templates/flume-conf.properties.j2
+++ b/ansible/roles/apache-flume/templates/flume-conf.properties.j2
@@ -15,13 +15,13 @@
 # specific language governing permissions and limitations
 # under the License.
 
-agent.sources ={% for topic in vars["topics"] %} {{ topic }}Source {% endfor %}
+agent.sources ={% for topic in topics %} {{ topic }}Source {% endfor %}
 
-agent.channels ={% for topic in vars["topics"] %} {{ topic }}Channel {% endfor %}
+agent.channels ={% for topic in topics %} {{ topic }}Channel {% endfor %}
 
-agent.sinks ={% for topic in vars["topics"] %} {{ topic }}Sink {% endfor %}
+agent.sinks ={% for topic in topics %} {{ topic }}Sink {% endfor %}
 
-{% for topic in vars["topics"] %}
+{% for topic in topics %}
 
 agent.sources.{{ topic }}Source.type = org.apache.flume.source.kafka.KafkaSource
 agent.sources.{{ topic }}Source.zookeeperConnect = master:2181

--- a/ansible/roles/apache-flume/templates/flume-conf.properties.j2
+++ b/ansible/roles/apache-flume/templates/flume-conf.properties.j2
@@ -15,9 +15,11 @@
 # specific language governing permissions and limitations
 # under the License.
 
-agent.sources = {% for topic in vars["topics"] %} {{ topic }}Source {% endfor %}
-agent.channels = {% for topic in vars["topics"] %} {{ topic }}Channel {% endfor %}
-agent.sinks = {% for topic in vars["topics"] %} {{ topic }}Sink {% endfor %}
+agent.sources ={% for topic in vars["topics"] %} {{ topic }}Source {% endfor %}
+
+agent.channels ={% for topic in vars["topics"] %} {{ topic }}Channel {% endfor %}
+
+agent.sinks ={% for topic in vars["topics"] %} {{ topic }}Sink {% endfor %}
 
 {% for topic in vars["topics"] %}
 
@@ -26,7 +28,7 @@ agent.sources.{{ topic }}Source.zookeeperConnect = master:2181
 agent.sources.{{ topic }}Source.topic = {{ topic }}
 agent.sources.{{ topic }}Source.groupId = flume
 agent.sources.{{ topic }}Source.kafka.consumer.timeout.ms = 100
-agent.sources.{{ topic }}Source.channel = {{ topic }}Channel
+agent.sources.{{ topic }}Source.channels = {{ topic }}Channel
 
 agent.channels.{{ topic }}Channel.type = memory
 

--- a/ansible/roles/apache-flume/vars/main.yml
+++ b/ansible/roles/apache-flume/vars/main.yml
@@ -1,0 +1,6 @@
+---
+mirror_url: "http://apache.tsl.gr/flume"
+version: "1.6.0"
+download_path: "/root"
+installation_path: "/usr/local"
+topics: ["input"]

--- a/ansible/roles/apache-kafka/handlers/main.yml
+++ b/ansible/roles/apache-kafka/handlers/main.yml
@@ -1,4 +1,4 @@
 ---
 - name: create topics
-  shell: "{{ installation_path }}/kafka/bin/kafka-topics.sh --create --zookeeper {{ hostvars[groups['master'][0]]['internal_ip'] }}:2181 --replica-assignment 0:1 --topic {{ item }}"
+  shell: "{{ installation_path }}/kafka/bin/kafka-topics.sh --create --zookeeper {{ hostvars[groups['master'][0]]['internal_ip'] }}:2181 --replica-assignment 0 --topic {{ item }}"
   with_items: "{{ topics }}"

--- a/ansible/roles/common/tasks/common.yml
+++ b/ansible/roles/common/tasks/common.yml
@@ -54,6 +54,7 @@
 
   - name: Add flume user to sudo group.
     user: name=flume group=sudo
+    when: "'master' in group_names"
 
   - name: Install supervisord with apt.
     apt: name=supervisor state=latest

--- a/ansible/roles/common/tasks/common.yml
+++ b/ansible/roles/common/tasks/common.yml
@@ -52,6 +52,9 @@
   - name: Add kafka user to sudo group.
     user: name=kafka group=sudo
 
+  - name: Add flume user to sudo group.
+    user: name=flume group=sudo
+
   - name: Install supervisord with apt.
     apt: name=supervisor state=latest
     environment: proxy_env

--- a/ansible/roles/common/tasks/master.yml
+++ b/ansible/roles/common/tasks/master.yml
@@ -3,6 +3,11 @@
   - name: Create users for each application.
     include: users.yml
 
+  - name: Create flume user
+    user: name=flume uid=2013 groups="lambda" shell=/bin/bash
+    tags:
+      - users
+
   - name: Generate ssh key for hduser
     user: name=hduser generate_ssh_key=yes
     tags:

--- a/ansible/roles/common/templates/lambda-init.j2
+++ b/ansible/roles/common/templates/lambda-init.j2
@@ -127,6 +127,22 @@ start(){
     log "Apache Flink has been started!"
   fi
 
+  # Start Apache Flume.
+  log "Starting Apache Flume..."
+  supervisorctl start apache_flume
+  # Wait for Apache Flume to start.
+  while [ "$(supervisorctl status apache_flume | tr -s ' ' | cut -f2 -d' ')" == "STARTING" ]
+  do
+    sleep 10
+  done
+  apache_flume_status=$(supervisorctl status apache_flume | tr -s ' ' | cut -f2 -d' ')
+  if [ "$apache_flume_status" != "RUNNING" ]
+  then
+    log "Apache Flume has failed to start with code $apache_flume_status."
+  else
+    log "Apache Flume has been started!"
+  fi
+
   # Create a lock file to prevent multiple instantiations.
   touch $LOCKFILE
 
@@ -211,6 +227,16 @@ stop(){
     log "Apache Zookeeper has been stopped!"
   else
     log "Apache Zookeeper has failed to stop with returned code $apache_zookeeper_status"
+  fi
+
+  # Stop Apache Flume.
+  supervisorctl stop apache_flume
+  apache_flume_status=$(supervisorctl status flume_zookeeper | tr -s ' ' | cut -f2 -d' ')
+  if [ "$apache_flume_status" == "STOPPED" ]
+  then
+    log "Apache Flume has been stopped!"
+  else
+    log "Apache Flume has failed to stop with returned code $apache_flume_status"
   fi
 
   # Stop Supervisord on master node.

--- a/ansible/roles/common/templates/lambda-init.j2
+++ b/ansible/roles/common/templates/lambda-init.j2
@@ -231,7 +231,7 @@ stop(){
 
   # Stop Apache Flume.
   supervisorctl stop apache_flume
-  apache_flume_status=$(supervisorctl status flume_zookeeper | tr -s ' ' | cut -f2 -d' ')
+  apache_flume_status=$(supervisorctl status apache_flume | tr -s ' ' | cut -f2 -d' ')
   if [ "$apache_flume_status" == "STOPPED" ]
   then
     log "Apache Flume has been stopped!"

--- a/ansible/roles/common/templates/supervisord-master.conf.j2
+++ b/ansible/roles/common/templates/supervisord-master.conf.j2
@@ -99,8 +99,8 @@ command=bin/flume-ng agent --conf conf -f conf/flume-conf.properties -n flume_ag
 autostart=false
 user=flume
 stopasgroup=true
-stderr_logfile={{ flume_home }}/supervisord_flume_stderr_logs.log
-stdout_logfile={{ flume_home }}/supervisord_flume_stdout_logs.log
+stderr_logfile=/home/flume/supervisord_flume_stderr_logs.log
+stdout_logfile=/home/flume/supervisord_flume_stdout_logs.log
 
 ;[program:theprogramname]
 ;command=/bin/cat              ; the program (relative uses PATH, can take args)

--- a/ansible/roles/common/templates/supervisord-master.conf.j2
+++ b/ansible/roles/common/templates/supervisord-master.conf.j2
@@ -95,12 +95,13 @@ stdout_logfile=/home/flink/supervisord_flink_streaming_logs.log
 
 [program:apache_flume]
 directory={{ flume_home }}
-command=bash bin/flume-ng agent --conf conf -f conf/flume-conf.properties -n flume_agent
+command=bash bin/flume-ng agent --conf conf -f conf/flume-conf.properties -n agent
 autostart=false
 user=flume
 stopasgroup=true
 stderr_logfile=/home/flume/supervisord_flume_stderr_logs.log
 stdout_logfile=/home/flume/supervisord_flume_stdout_logs.log
+environment=JAVA_HOME="/usr",HADOOP_HOME="/usr/local/hadoop",HADOOP_CONF_DIR="/usr/local/hadoop/etc/hadoop/"
 
 ;[program:theprogramname]
 ;command=/bin/cat              ; the program (relative uses PATH, can take args)

--- a/ansible/roles/common/templates/supervisord-master.conf.j2
+++ b/ansible/roles/common/templates/supervisord-master.conf.j2
@@ -93,6 +93,15 @@ autostart=false
 user=flink
 stdout_logfile=/home/flink/supervisord_flink_streaming_logs.log
 
+[program:apache_flume]
+directory={{ flume_home }}
+command=bin/flume-ng agent --conf conf -f conf/flume-conf.properties -n flume_agent
+autostart=false
+user=flume
+stopasgroup=true
+stderr_logfile={{ flume_home }}/supervisord_flume_stderr_logs.log
+stdout_logfile={{ flume_home }}/supervisord_flume_stdout_logs.log
+
 ;[program:theprogramname]
 ;command=/bin/cat              ; the program (relative uses PATH, can take args)
 ;process_name=%(program_name)s ; process_name expr (default %(program_name)s)

--- a/ansible/roles/common/templates/supervisord-master.conf.j2
+++ b/ansible/roles/common/templates/supervisord-master.conf.j2
@@ -95,7 +95,7 @@ stdout_logfile=/home/flink/supervisord_flink_streaming_logs.log
 
 [program:apache_flume]
 directory={{ flume_home }}
-command=bin/flume-ng agent --conf conf -f conf/flume-conf.properties -n flume_agent
+command=bash bin/flume-ng agent --conf conf -f conf/flume-conf.properties -n flume_agent
 autostart=false
 user=flume
 stopasgroup=true

--- a/ansible/roles/common/templates/supervisord-master.conf.j2
+++ b/ansible/roles/common/templates/supervisord-master.conf.j2
@@ -75,7 +75,7 @@ user=flink
 stopsignal=INT
 stopasgroup=true
 stdout_logfile=/home/flink/supervisord_flink_logs.log
-environment=JAVA_HOME="/usr",HADOOP_HOME="/usr/local/hadoop",HADOOP_CONF_DIR="/usr/local/hadoop/etc/hadoop/"
+environment=JAVA_HOME="/usr",HADOOP_HOME="{{ hadoop_home }}",HADOOP_CONF_DIR="{{ hadoop_home }}/etc/hadoop/"
 
 [program:flink_batch_job]
 directory=/home/flink
@@ -101,7 +101,7 @@ user=flume
 stopasgroup=true
 stderr_logfile=/home/flume/supervisord_flume_stderr_logs.log
 stdout_logfile=/home/flume/supervisord_flume_stdout_logs.log
-environment=JAVA_HOME="/usr",HADOOP_HOME="/usr/local/hadoop",HADOOP_CONF_DIR="/usr/local/hadoop/etc/hadoop/"
+environment=JAVA_HOME="/usr",HADOOP_HOME="{{ hadoop_home }}",HADOOP_CONF_DIR="{{ hadoop_home }}/etc/hadoop/"
 
 ;[program:theprogramname]
 ;command=/bin/cat              ; the program (relative uses PATH, can take args)

--- a/ansible/roles/common/vars/main.yml
+++ b/ansible/roles/common/vars/main.yml
@@ -3,5 +3,6 @@ java_home: "/usr"
 hadoop_home: "/usr/local/hadoop"
 kafka_home: "/usr/local/kafka"
 flink_home: "/usr/local/flink"
+flume_home: "/usr/local/flume"
 flink_number_of_task_managers: "{{ groups['slaves']|count }}"
 flink_ram_per_task_manager: 768

--- a/example/batch_word_count/src/main/java/org/grnet/batch/Main.java
+++ b/example/batch_word_count/src/main/java/org/grnet/batch/Main.java
@@ -32,7 +32,7 @@ import java.util.List;
 public class Main {
     public static void main(String[] args) throws Exception {
         // HDFS configuration.
-        String inputHDFSDirectory = "hdfs:///user/flink/input";
+        String inputHDFSDirectory = "hdfs:///user/flume/input";
         String outputHDFSDirectory = "hdfs:///user/flink/output";
 
         // Apache Kafka configuration.

--- a/webapp/backend/models.py
+++ b/webapp/backend/models.py
@@ -159,6 +159,8 @@ class LambdaInstance(models.Model):
     KAFKA_FAILED = "19"
     FLINK_INSTALLED = "20"
     FLINK_FAILED = "21"
+    FLUME_INSTALLED = "22"
+    FLUME_FAILED = "23"
     status_choices = (
         (STARTED, 'STARTED'),
         (STOPPED, 'STOPPED'),
@@ -182,6 +184,8 @@ class LambdaInstance(models.Model):
         (KAFKA_FAILED, 'KAFKA_FAILED'),
         (FLINK_INSTALLED, 'FLINK_INSTALLED'),
         (FLINK_FAILED, 'FLINK_FAILED'),
+        (FLUME_INSTALLED, 'FLUME_INSTALLED'),
+        (FLUME_FAILED, 'FLUME_FAILED')
     )
     status = models.CharField(max_length=10, choices=status_choices, default=PENDING,
                               help_text="The status of this instance.")

--- a/webapp/backend/response_messages.py
+++ b/webapp/backend/response_messages.py
@@ -52,7 +52,9 @@ class ResponseMessages:
         'KAFKA_INSTALLED': "Apache Kafka has been successfully installed and configured",
         'KAFKA_FAILED': "Apache Kafka installation and configuration have failed",
         'FLINK_INSTALLED': "Apache Flink has been successfully installed and configured",
-        'FLINK_FAILED': "Apache Flink installation and configuration have failed"
+        'FLINK_FAILED': "Apache Flink installation and configuration have failed",
+        'FLUME_INSTALLED': "Apache Flume has been successfully installed and configured",
+        'FLUME_FAILED': "Apache Flume installation and configuration have failed"
     }
 
     application_status_details = {

--- a/webapp/backend/serializers.py
+++ b/webapp/backend/serializers.py
@@ -111,8 +111,9 @@ class LambdaInstanceInfo(serializers.Serializer):
     disk_slave = serializers.IntegerField()
     network_request = serializers.IntegerField(default=1)
     public_key_name = serializers.ListField(required=False, default=[])
-    kafka_topics = serializers.ListField(required=False, default=["input", "stream-output",
-                                                                  "batch-output"])
+    kafka_input_topics = serializers.ListField(required=False, default=["input"])
+    kafka_output_topics = serializers.ListField(required=False, default=["stream-output",
+                                                                         "batch-output"])
 
     # Allowed values for vm parameters. They will be changed dynamically in the view that will
     # be called to create a new lambda instance. These entries are kept here in case the view

--- a/webapp/backend/tasks.py
+++ b/webapp/backend/tasks.py
@@ -245,10 +245,12 @@ def create_lambda_instance(lambda_info, auth_token):
             set_lambda_instance_status_central_vm.delay(auth_token, instance_uuid,
                                                         LambdaInstance.HADOOP_INSTALLED, "")
 
-    ansible_result = lambda_instance_manager.run_playbook(ansible_manager, 'kafka-install.yml',
-                                                          only_tags=ansible_tags,
-                                                          extra_vars={
-                                                              'topics': specs['kafka_topics']})
+    ansible_result = lambda_instance_manager.\
+        run_playbook(ansible_manager, 'kafka-install.yml', only_tags=ansible_tags,
+                     extra_vars={
+                         'topics': list(set(specs['kafka_input_topics'] +
+                                            specs['kafka_output_topics']))
+                     })
     check = _check_ansible_result(ansible_result)
     if check != 'Ansible successful':
         events.set_lambda_instance_status.delay(instance_uuid=instance_uuid,
@@ -283,8 +285,11 @@ def create_lambda_instance(lambda_info, auth_token):
             set_lambda_instance_status_central_vm.delay(auth_token, instance_uuid,
                                                         LambdaInstance.FLINK_INSTALLED, "")
 
-    ansible_result = lambda_instance_manager.run_playbook(ansible_manager, 'flume-install.yml',
-                                                          only_tags=ansible_tags)
+    ansible_result = lambda_instance_manager.\
+        run_playbook(ansible_manager, 'flume-install.yml', only_tags=ansible_tags,
+                     extra_vars={
+                         'topics': list(set(specs['kafka_input_topics']))
+                     })
     check = _check_ansible_result(ansible_result)
     if check != 'Ansible successful':
         events.set_lambda_instance_status.delay(instance_uuid=instance_uuid,

--- a/webapp/backend/tasks.py
+++ b/webapp/backend/tasks.py
@@ -283,6 +283,24 @@ def create_lambda_instance(lambda_info, auth_token):
             set_lambda_instance_status_central_vm.delay(auth_token, instance_uuid,
                                                         LambdaInstance.FLINK_INSTALLED, "")
 
+    ansible_result = lambda_instance_manager.run_playbook(ansible_manager, 'flume-install.yml',
+                                                          only_tags=ansible_tags)
+    check = _check_ansible_result(ansible_result)
+    if check != 'Ansible successful':
+        events.set_lambda_instance_status.delay(instance_uuid=instance_uuid,
+                                                status=LambdaInstance.FLUME_FAILED,
+                                                failure_message=check)
+        central_vm_tasks.\
+            set_lambda_instance_status_central_vm.delay(auth_token, instance_uuid,
+                                                        LambdaInstance.FLUME_FAILED, check)
+        return
+    else:
+        events.set_lambda_instance_status.delay(instance_uuid=instance_uuid,
+                                                status=LambdaInstance.FLUME_INSTALLED)
+        central_vm_tasks.\
+            set_lambda_instance_status_central_vm.delay(auth_token, instance_uuid,
+                                                        LambdaInstance.FLUME_INSTALLED, "")
+
     # Set lambda instance status to started.
     events.set_lambda_instance_status.delay(instance_uuid=instance_uuid,
                                             status=LambdaInstance.STARTED)

--- a/webapp/frontend/app/components/create-lambda-instance-form.js
+++ b/webapp/frontend/app/components/create-lambda-instance-form.js
@@ -27,12 +27,12 @@ export default Ember.Component.extend({
 
       var kafkaInputTopicsString = this.get("kafkaInputTopics");
       if (kafkaInputTopicsString) {
-        newLambdaInstance.set('kafkaInputTopics', kafkaInputTopicsString.split(','));
+        newLambdaInstance.set('kafkaInputTopics', kafkaInputTopicsString.replace(/\s+/g, '').split(','));
       }
 
       var kafkaOutputTopicsString = this.get("kafkaOutputTopics");
       if (kafkaOutputTopicsString) {
-        newLambdaInstance.set('kafkaOutputTopics', kafkaOutputTopicsString.split(','));
+        newLambdaInstance.set('kafkaOutputTopics', kafkaOutputTopicsString.replace(/\s+/g, '').split(','));
       }
 
       this.sendAction('saveAction', newLambdaInstance);

--- a/webapp/frontend/app/components/create-lambda-instance-form.js
+++ b/webapp/frontend/app/components/create-lambda-instance-form.js
@@ -25,9 +25,14 @@ export default Ember.Component.extend({
       }
       newLambdaInstance.set('publicKeyName', requestedPublicKeys);
 
-      var kafkaTopicsString = this.get("kafkaTopics");
-      if (kafkaTopicsString) {
-        newLambdaInstance.set('kafkaTopics', kafkaTopicsString.split(','));
+      var kafkaInputTopicsString = this.get("kafkaInputTopics");
+      if (kafkaInputTopicsString) {
+        newLambdaInstance.set('kafkaInputTopics', kafkaInputTopicsString.split(','));
+      }
+
+      var kafkaOutputTopicsString = this.get("kafkaOutputTopics");
+      if (kafkaOutputTopicsString) {
+        newLambdaInstance.set('kafkaOutputTopics', kafkaOutputTopicsString.split(','));
       }
 
       this.sendAction('saveAction', newLambdaInstance);

--- a/webapp/frontend/app/helpers/lambda-instance-state-flow.js
+++ b/webapp/frontend/app/helpers/lambda-instance-state-flow.js
@@ -4,19 +4,21 @@ export default Ember.Helper.helper(function(parameters) {
   var status_message = parameters[0];
   switch (status_message) {
     case "PENDING":
-      return "1/7";
+      return "1/8";
     case "CLUSTER_CREATED":
-      return "2/7";
+      return "2/8";
     case "INIT_DONE":
-      return "3/7";
+      return "3/8";
     case "COMMONS_INSTALLED":
-      return "4/7";
+      return "4/8";
     case "HADOOP_INSTALLED":
-      return "5/7";
+      return "5/8";
     case "KAFKA_INSTALLED":
-      return "6/7";
+      return "6/8";
     case "FLINK_INSTALLED":
-      return "7/7";
+      return "7/8";
+    case "FLUME_INSTALLED":
+      return "8/8";
   }
   return "";
 });

--- a/webapp/frontend/app/helpers/lambda-instance-state.js
+++ b/webapp/frontend/app/helpers/lambda-instance-state.js
@@ -14,6 +14,7 @@ export default Ember.Helper.helper(function(parameters) {
     case "HADOOP_FAILED":
     case "KAFKA_FAILED":
     case "FLINK_FAILED":
+    case "FLUME_FAILED":
       return "FAILED";
     case "STOPPED":
       return "STOPPED";
@@ -24,6 +25,7 @@ export default Ember.Helper.helper(function(parameters) {
     case "HADOOP_INSTALLED":
     case "KAFKA_INSTALLED":
     case "FLINK_INSTALLED":
+    case "FLUME_INSTALLED":
       return "BUILDING";
     case "STOPPING":
     case "STARTING":

--- a/webapp/frontend/app/models/create-lambda-instance.js
+++ b/webapp/frontend/app/models/create-lambda-instance.js
@@ -13,5 +13,6 @@ export default DS.Model.extend({
   DiskSlave: DS.attr('number',  {defaultValue: 20}),
   ipAllocation: DS.attr('string',  {defaultValue: "master"}),
   publicKeyName: DS.attr({defaultValue: []}),
-  kafkaTopics: DS.attr()
+  kafkaInputTopics: DS.attr(),
+  kafkaOutputTopics: DS.attr()
 });

--- a/webapp/frontend/app/models/lambda-instance.js
+++ b/webapp/frontend/app/models/lambda-instance.js
@@ -21,7 +21,8 @@ var LambdaInstance = DS.Model.extend({
   applications: DS.hasMany('lambda-app'),   // deployed applications
   started_app: DS.attr('boolean'),          // is specific app started?
   running_app: DS.attr('boolean'),          // is any app running on the lambda instance?
-  kafka_topics: DS.attr()                   // kafka topics of lambda instance
+  kafka_input_topics: DS.attr(),            // kafka input topics of lambda instance
+  kafka_output_topics: DS.attr()            // kafka output topics of lambda instance
 });
 
 export default LambdaInstance;

--- a/webapp/frontend/app/templates/components/create-lambda-instance-form.hbs
+++ b/webapp/frontend/app/templates/components/create-lambda-instance-form.hbs
@@ -79,42 +79,46 @@
               </div>
             </div>
             <div class="row">
-              <div class="form-group col-sm-6">
+              <div class="form-group col-sm-8">
                 <label for="okeanos_project" class="col-sm-6">~okeanos Project (*):</label>
-                <div class="col-sm-6">
                   <select name="okeanos_project" class="form-control">
                     {{#each userOkeanosProjects as |project|}}
                     <option value={{project.name}}>{{project.name}} (VMs: {{project.vm}}, CPUs: {{project.cpu}}, RAM: {{normalize-bytes project.ram}}, Disk: {{normalize-bytes project.disk}}, Floating IPs: {{project.floating_ip}}, Private Networks: {{project.private_network}})</option>
                     {{/each}}
                   </select>
-                  <span id="helpBlock" class="help-block">Select a project</span>
-                </div>	<!--class="col-sm-6"-->
-                <label for="slaves" class="col-sm-6">Number of slaves:</label>
-                <div class="col-sm-6">
-                  <input type="number" min="1" value="2" name="slaves">
-                  <span id="helpBlock" class="help-block">Select the number of slaves</span>
-                </div>	<!--class="col-sm-6"-->
+                <span id="helpBlock" class="help-block">Select a project</span>
               </div>	<!--class="col-sm-6"-->
+              <div class="form-group col-sm-3">
+                <label for="slaves">Number of slaves:</label>
+                  <input type="number" min="1" value="2" name="slaves" class="form-control">
+                  <span id="helpBlock" class="help-block">Select the number of slaves</span>
+              </div>	<!--class="form-group col-sm-3"-->
+            </div>
+            <div class="row">
               <div class="form-group col-sm-6">
-                <label for="public_key_name"  class="col-sm-6">Public SSH keys (*):</label>
-                <div class="col-sm-6">
+                <label for="kafka_topics">Apache Kafka input topics:</label>
+                  {{input type="text" value=kafkaInputTopics placeholder="e.g. name1,name2,name3" size="50" class="form-control"}}
+                  <span id="helpBlock" class="help-block">Names of Apache Kafka input topics</span>
+              </div>
+              <div class="form-group col-sm-6 pull-right">
+                <label for="kafka_topics">Apache Kafka output topics:</label>
+                  {{input type="text" value=kafkaOutputTopics placeholder="e.g. name1,name2,name3" size="50" class="form-control"}}
+                  <span id="helpBlock" class="help-block">Names of Apache Kafka output topics</span>
+              </div>
+            </div><!--row-->
+            <div class="row">
+              <div class="form-group col-sm-3">
+                <label for="public_key_name">Public SSH keys (*):</label>
                   <select required="required" multiple name="public_key_name" class="form-control">
                     {{#each userPublicKeys as |publicKey|}}
                     <option value={{publicKey.name}}>{{publicKey.name}}</option>
                     {{/each}}
                   </select>
-                  <span id="helpBlock" class="help-block">Select the public SSH keys to upload</span>
-                </div><!--class="col-sm-6"-->
-              </div><!--class="form-group col-sm-6"-->
-            </div> <!--row-->
-            <div class="row">
-              <div class="form-group col-sm-6">
-                <label for="kafka_topics" class="col-sm-6">Apache Kafka topics:</label>
-                <div class="col-sm-6">
-                  {{input type="text" value=kafkaTopics placeholder="e.g. name1,name2,name3" size="50" class="form-control"}}
-                  <span id="helpBlock" class="help-block">Names of Apache Kafka topics</span>
-                </div>  <!--class="col-sm-6"-->
               </div>
+              <div class="form-group col-sm-2">
+              <br/>
+                  <span id="helpBlock" class="help-block">Select the public SSH keys to upload to the lamdba instance vms. By selecting ssh keys, you will get access to these vms.</span>
+              </div><!--class="form-group col-sm-6"-->
             </div><!--row-->
           </div><!--box-body-->
         </div><!--box-->

--- a/webapp/frontend/app/templates/lambda-instance.hbs
+++ b/webapp/frontend/app/templates/lambda-instance.hbs
@@ -153,8 +153,12 @@
                     <td>{{model.instance.disk_slave}}GB</td>
                   </tr>
                   <tr>
-                      <th>Kafka topics</th>
-                      <td>{{model.instance.kafka_topics}}</td>
+                      <th>Kafka input topics(broker port: 9092)</th>
+                      <td>{{model.instance.kafka_input_topics}}</td>
+                  </tr>
+                  <tr>
+                      <th>Kafka output topics(zookeeper port: 2181)</th>
+                      <td>{{model.instance.kafka_output_topics}}</td>
                   </tr>
                   {{#if model.instance.public_key_name}}
                   <tr>

--- a/webapp/tests/test_celery_tasks.py
+++ b/webapp/tests/test_celery_tasks.py
@@ -670,6 +670,18 @@ class TestCeleryTasks(APITestCase):
         mock_set_lambda_instance_status_central_vm.delay. \
             assert_any_call(self.AUTHENTICATION_TOKEN, None, LambdaInstance.FLINK_INSTALLED, "")
 
+        mock_lambda_instance_manager_fokia.run_playbook. \
+            assert_any_call(mock_ansible_manager, 'flume-install.yml',
+                            only_tags=['image-configure'],
+                            extra_vars={
+                                'topics': list(set(specs['kafka_input_topics']))
+                            })
+        mock_check_ansible_result.assert_any_call(mock_ansible_result)
+        mock_set_lambda_instance_status_event.delay. \
+            assert_any_call(instance_uuid=None, status=LambdaInstance.FLUME_INSTALLED)
+        mock_set_lambda_instance_status_central_vm.delay. \
+            assert_any_call(self.AUTHENTICATION_TOKEN, None, LambdaInstance.FLUME_INSTALLED, "")
+
         mock_set_lambda_instance_status_event.delay. \
             assert_any_call(instance_uuid=None, status=LambdaInstance.STARTED)
         mock_set_lambda_instance_status_central_vm.delay. \
@@ -1346,6 +1358,163 @@ class TestCeleryTasks(APITestCase):
                             failure_message="Ansible task failed")
         mock_set_lambda_instance_status_central_vm.delay. \
             assert_any_call(self.AUTHENTICATION_TOKEN, None, LambdaInstance.FLINK_FAILED,
+                            "Ansible task failed")
+
+    @mock.patch('backend.central_vm_tasks.set_lambda_instance_status_central_vm')
+    @mock.patch('backend.central_vm_tasks.create_lambda_instance_central_vm')
+    @mock.patch('backend.tasks._check_ansible_result')
+    @mock.patch('backend.tasks.get_named_keys', return_value={'key-1': "ssh", 'key-2': "ssh2"})
+    @mock.patch('backend.tasks.lambda_instance_manager')
+    @mock.patch('backend.tasks.events.insert_cluster_info')
+    @mock.patch('backend.tasks.events.set_lambda_instance_status')
+    @mock.patch('backend.tasks.events.create_new_lambda_instance')
+    @mock.patch('backend.tasks.settings')
+    def test_create_lambda_instance_flume_fail(self, django_settings,
+                                               mock_create_new_lambda_instance_event,
+                                               mock_set_lambda_instance_status_event,
+                                               mock_insert_cluster_info_event,
+                                               mock_lambda_instance_manager_fokia,
+                                               mock_get_named_keys, mock_check_ansible_result,
+                                               mock_create_lambda_instance_central_vm,
+                                               mock_set_lambda_instance_status_central_vm):
+        # Setup mock return values and side effects.
+        mock_ansible_manager = mock.Mock()
+        mock_provisioner_response = mock.Mock()
+
+        django_settings.MASTER_IMAGE_ID = "master_image_id"
+        django_settings.SLAVE_IMAGE_ID = "slave_image_id"
+
+        mock_lambda_instance_manager_fokia.create_cluster.return_value = mock_ansible_manager, \
+                                                                         mock_provisioner_response
+
+        mock_ansible_result = mock.Mock()
+        mock_lambda_instance_manager_fokia.run_playbook.return_value = mock_ansible_result
+
+        mock_check_ansible_result.side_effect = ["Ansible successful",
+                                                 "Ansible successful",
+                                                 "Ansible successful",
+                                                 "Ansible successful",
+                                                 "Ansible successful",
+                                                 "Ansible task failed"]
+
+        # Create the input that will be given to the task.
+        specs = {
+            'instance_name': "Lambda Instance created from Tests",
+            'public_key_name': ['key-1', 'key-2'],
+            'master_name': "master_name",
+            'master_image_id': "master_image_id",
+            'slave_image_id': "slave_image_id",
+            'slaves': 2,
+            'vcpus_master': 4,
+            'vcpus_slave': 8,
+            'ram_master': 4096,
+            'ram_slave': 8192,
+            'disk_master': 20,
+            'disk_slave': 40,
+            'ip_allocation': 'master',
+            'network_request': 1,
+            'project_name': "lambda.grnet.gr",
+            'kafka_input_topics': ["input", "private_input"],
+            'kafka_output_topics': ["output", "stream_output", "batch_output"]
+        }
+        lambda_info = LambdaInfo(specs)
+
+        # Call create lambda instance task.
+        tasks.create_lambda_instance(lambda_info, self.AUTHENTICATION_TOKEN)
+
+        # Assert that the proper mocks have been called.
+        mock_create_new_lambda_instance_event.delay. \
+            assert_called_with(instance_uuid=None,
+                               instance_name="Lambda Instance created from Tests",
+                               specs=json.dumps(specs))
+        mock_create_lambda_instance_central_vm.delay. \
+            assert_called_with(auth_token=self.AUTHENTICATION_TOKEN,
+                               instance_uuid=None,
+                               instance_name="Lambda Instance created from Tests",
+                               specs=json.dumps(specs))
+        mock_get_named_keys.assert_called_with(self.AUTHENTICATION_TOKEN,
+                                               names=['key-1', 'key-2'])
+        mock_lambda_instance_manager_fokia.create_cluster. \
+            assert_called_with(cluster_id=None,
+                               auth_token=self.AUTHENTICATION_TOKEN, master_name="master_name",
+                               master_image_id="master_image_id", slave_image_id="slave_image_id",
+                               slaves=2, vcpus_master=4, vcpus_slave=8, ram_master=4096,
+                               ram_slave=8192, disk_master=20, disk_slave=40,
+                               ip_allocation="master", network_request=1,
+                               project_name="lambda.grnet.gr",
+                               pub_keys={'key-1': "ssh", 'key-2': "ssh2"})
+        mock_set_lambda_instance_status_event.delay. \
+            assert_any_call(instance_uuid=None, status=LambdaInstance.CLUSTER_CREATED)
+        mock_set_lambda_instance_status_central_vm.delay. \
+            assert_any_call(self.AUTHENTICATION_TOKEN, None, LambdaInstance.CLUSTER_CREATED, "")
+        mock_insert_cluster_info_event.delay. \
+            assert_called_with(instance_uuid=None, provisioner_response=mock_provisioner_response,
+                               specs=specs)
+
+        mock_lambda_instance_manager_fokia.run_playbook. \
+            assert_any_call(mock_ansible_manager,
+                            'initialize.yml',
+                            only_tags=['common-configure'])
+        mock_check_ansible_result.assert_any_call(mock_ansible_result)
+        mock_set_lambda_instance_status_event.delay. \
+            assert_any_call(instance_uuid=None, status=LambdaInstance.INIT_DONE)
+        mock_set_lambda_instance_status_central_vm.delay. \
+            assert_any_call(self.AUTHENTICATION_TOKEN, None, LambdaInstance.INIT_DONE, "")
+
+        mock_lambda_instance_manager_fokia.run_playbook. \
+            assert_any_call(mock_ansible_manager,
+                            'common-install.yml',
+                            only_tags=['common-configure', 'image-configure'])
+        mock_check_ansible_result.assert_any_call(mock_ansible_result)
+        mock_set_lambda_instance_status_event.delay. \
+            assert_any_call(instance_uuid=None, status=LambdaInstance.COMMONS_INSTALLED)
+        mock_set_lambda_instance_status_central_vm.delay. \
+            assert_any_call(self.AUTHENTICATION_TOKEN, None, LambdaInstance.COMMONS_INSTALLED, "")
+
+        mock_lambda_instance_manager_fokia.run_playbook. \
+            assert_any_call(mock_ansible_manager,
+                            'hadoop-install.yml',
+                            only_tags=['image-configure'])
+        mock_check_ansible_result.assert_any_call(mock_ansible_result)
+        mock_set_lambda_instance_status_event.delay. \
+            assert_any_call(instance_uuid=None, status=LambdaInstance.HADOOP_INSTALLED)
+        mock_set_lambda_instance_status_central_vm.delay. \
+            assert_any_call(self.AUTHENTICATION_TOKEN, None, LambdaInstance.HADOOP_INSTALLED, "")
+
+        mock_lambda_instance_manager_fokia. \
+            run_playbook.assert_any_call(mock_ansible_manager, 'kafka-install.yml',
+                                         only_tags=['image-configure'],
+                                         extra_vars={
+                                             'topics': list(set(specs['kafka_input_topics'] +
+                                                                specs['kafka_output_topics']))
+                                         })
+        mock_check_ansible_result.assert_any_call(mock_ansible_result)
+        mock_set_lambda_instance_status_event.delay. \
+            assert_any_call(instance_uuid=None, status=LambdaInstance.KAFKA_INSTALLED)
+        mock_set_lambda_instance_status_central_vm.delay. \
+            assert_any_call(self.AUTHENTICATION_TOKEN, None, LambdaInstance.KAFKA_INSTALLED, "")
+
+        mock_lambda_instance_manager_fokia.run_playbook. \
+            assert_any_call(mock_ansible_manager, 'flink-install.yml',
+                            only_tags=['image-configure'])
+        mock_check_ansible_result.assert_any_call(mock_ansible_result)
+        mock_set_lambda_instance_status_event.delay. \
+            assert_any_call(instance_uuid=None, status=LambdaInstance.FLINK_INSTALLED)
+        mock_set_lambda_instance_status_central_vm.delay. \
+            assert_any_call(self.AUTHENTICATION_TOKEN, None, LambdaInstance.FLINK_INSTALLED, "")
+
+        mock_lambda_instance_manager_fokia.run_playbook. \
+            assert_any_call(mock_ansible_manager, 'flume-install.yml',
+                            only_tags=['image-configure'],
+                            extra_vars={
+                                'topics': list(set(specs['kafka_input_topics']))
+                            })
+        mock_check_ansible_result.assert_any_call(mock_ansible_result)
+        mock_set_lambda_instance_status_event.delay. \
+            assert_any_call(instance_uuid=None, status=LambdaInstance.FLUME_FAILED,
+                            failure_message="Ansible task failed")
+        mock_set_lambda_instance_status_central_vm.delay. \
+            assert_any_call(self.AUTHENTICATION_TOKEN, None, LambdaInstance.FLUME_FAILED,
                             "Ansible task failed")
 
 

--- a/webapp/tests/test_celery_tasks.py
+++ b/webapp/tests/test_celery_tasks.py
@@ -578,7 +578,8 @@ class TestCeleryTasks(APITestCase):
             'ip_allocation': 'master',
             'network_request': 1,
             'project_name': "lambda.grnet.gr",
-            'kafka_topics': ["input", "output", "stream_output", "batch_output"]
+            'kafka_input_topics': ["input", "private_input"],
+            'kafka_output_topics': ["output", "stream_output", "batch_output"]
         }
         lambda_info = LambdaInfo(specs)
 
@@ -648,7 +649,10 @@ class TestCeleryTasks(APITestCase):
         mock_lambda_instance_manager_fokia. \
             run_playbook.assert_any_call(mock_ansible_manager, 'kafka-install.yml',
                                          only_tags=['image-configure'],
-                                         extra_vars={'topics': specs['kafka_topics']})
+                                         extra_vars={
+                                             'topics': list(set(specs['kafka_input_topics'] +
+                                                                specs['kafka_output_topics']))
+                                         })
 
         mock_check_ansible_result.assert_any_call(mock_ansible_result)
         mock_set_lambda_instance_status_event.delay. \
@@ -710,7 +714,8 @@ class TestCeleryTasks(APITestCase):
             'ip_allocation': 'master',
             'network_request': 1,
             'project_name': "lambda.grnet.gr",
-            'kafka_topics': ["input", "output", "stream_output", "batch_output"]
+            'kafka_input_topics': ["input", "private_input"],
+            'kafka_output_topics': ["output", "stream_output", "batch_output"]
         }
         lambda_info = LambdaInfo(specs)
 
@@ -791,7 +796,8 @@ class TestCeleryTasks(APITestCase):
             'ip_allocation': 'master',
             'network_request': 1,
             'project_name': "lambda.grnet.gr",
-            'kafka_topics': ["input", "output", "stream_output", "batch_output"]
+            'kafka_input_topics': ["input", "private_input"],
+            'kafka_output_topics': ["output", "stream_output", "batch_output"]
         }
         lambda_info = LambdaInfo(specs)
 
@@ -885,7 +891,8 @@ class TestCeleryTasks(APITestCase):
             'ip_allocation': 'master',
             'network_request': 1,
             'project_name': "lambda.grnet.gr",
-            'kafka_topics': ["input", "output", "stream_output", "batch_output"]
+            'kafka_input_topics': ["input", "private_input"],
+            'kafka_output_topics': ["output", "stream_output", "batch_output"]
         }
         lambda_info = LambdaInfo(specs)
 
@@ -992,7 +999,8 @@ class TestCeleryTasks(APITestCase):
             'ip_allocation': 'master',
             'network_request': 1,
             'project_name': "lambda.grnet.gr",
-            'kafka_topics': ["input", "output", "stream_output", "batch_output"]
+            'kafka_input_topics': ["input", "private_input"],
+            'kafka_output_topics': ["output", "stream_output", "batch_output"]
         }
         lambda_info = LambdaInfo(specs)
 
@@ -1112,7 +1120,8 @@ class TestCeleryTasks(APITestCase):
             'ip_allocation': 'master',
             'network_request': 1,
             'project_name': "lambda.grnet.gr",
-            'kafka_topics': ["input", "output", "stream_output", "batch_output"]
+            'kafka_input_topics': ["input", "private_input"],
+            'kafka_output_topics': ["output", "stream_output", "batch_output"]
         }
         lambda_info = LambdaInfo(specs)
 
@@ -1181,12 +1190,10 @@ class TestCeleryTasks(APITestCase):
         mock_lambda_instance_manager_fokia. \
             run_playbook.assert_any_call(mock_ansible_manager, 'kafka-install.yml',
                                          only_tags=['image-configure'],
-                                         extra_vars={'topics': specs['kafka_topics']})
-
-        mock_lambda_instance_manager_fokia. \
-            run_playbook.assert_any_call(mock_ansible_manager, 'kafka-install.yml',
-                                         only_tags=['image-configure'],
-                                         extra_vars={'topics': specs['kafka_topics']})
+                                         extra_vars={
+                                             'topics': list(set(specs['kafka_input_topics'] +
+                                                                specs['kafka_output_topics']))
+                                         })
 
         mock_check_ansible_result.assert_any_call(mock_ansible_result)
         mock_set_lambda_instance_status_event.delay. \
@@ -1249,7 +1256,8 @@ class TestCeleryTasks(APITestCase):
             'ip_allocation': 'master',
             'network_request': 1,
             'project_name': "lambda.grnet.gr",
-            'kafka_topics': ["input", "output", "stream_output", "batch_output"]
+            'kafka_input_topics': ["input", "private_input"],
+            'kafka_output_topics': ["output", "stream_output", "batch_output"]
         }
         lambda_info = LambdaInfo(specs)
 
@@ -1318,7 +1326,10 @@ class TestCeleryTasks(APITestCase):
         mock_lambda_instance_manager_fokia. \
             run_playbook.assert_any_call(mock_ansible_manager, 'kafka-install.yml',
                                          only_tags=['image-configure'],
-                                         extra_vars={'topics': specs['kafka_topics']})
+                                         extra_vars={
+                                             'topics': list(set(specs['kafka_input_topics'] +
+                                                                specs['kafka_output_topics']))
+                                         })
         mock_check_ansible_result.assert_any_call(mock_ansible_result)
         mock_set_lambda_instance_status_event.delay. \
             assert_any_call(instance_uuid=None, status=LambdaInstance.KAFKA_INSTALLED)

--- a/webapp/tests/test_lambda_instances.py
+++ b/webapp/tests/test_lambda_instances.py
@@ -46,7 +46,8 @@ class TestLambdaInstanceCreate(APITestCase):
                           'slaves': 2,
                           'ip_allocation': "master",
                           'public_key_name': ["key-1", "key-2"],
-                          'kafka_topics': ["input", "output", "stream_output", "batch_output"]}
+                          'kafka_input_topics': ["input", "private_input"],
+                          'kafka_output_topics': ["output", "stream_output", "batch_output"]}
 
     # Gather required fields.
     required_keys = ['project_name',


### PR DESCRIPTION
# Abstract

As a λ user, I want to be able to store a data stream as an immutable dataset
# Description

When data are sent to an Apache Kafka topic, they should be automatically saved on HDFS. 
# Implementation

Apache Flume will be used for reading data from Apache Kafka and saving them to HDFS. A single Apache Flume agent will run on the master node of each Lambda Instance listening to all Apache Kafka topics for data. When data arrive, the agent will save them on HDFS, into a directory with the same name as the topic the data came from.
# Implications
### Results get written on HDFS

If Apache Flume agent polls on every Apache Kafka topic, then, the job results sent to an Apache Kafka topic will be written to HDFS.
### Solution

Apache Kafka topics will be separated into two categories, namely "input" and "output". Apache Flume will only poll on topics that belong to "input" category so that the user can send job results to "output" topics without them being written to HDFS. Note that, it will be the users responsibility to use the "input" topics that he/she entered when creating the Lambda Instance for input, and the "output" topics for output.
