### PR TITLE
Possibility to delete instances that were not created due to not enough quotas, minor ansible improvements

### DIFF
--- a/ansible/roles/wait_for_ssh/tasks/main.yml
+++ b/ansible/roles/wait_for_ssh/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Wait for port 22 to be ready
-  local_action: wait_for port=22 host="{{ inventory_hostname }}"  search_regex=OpenSSH
+  local_action: wait_for port=22 host="{{ inventory_hostname }}"  search_regex=OpenSSH timeout=600
 
 - name: Wait for SSH SIGHUPs to stop
   pause: seconds=15

--- a/core/fokia/ansible_manager.py
+++ b/core/fokia/ansible_manager.py
@@ -92,7 +92,8 @@ class Manager:
         runner_cb = callbacks.PlaybookRunnerCallbacks(stats, verbose=utils.VERBOSITY)
         pb = PlayBook(playbook=playbook_file, inventory=self.ansible_inventory, stats=stats,
                       callbacks=playbook_cb, runner_callbacks=runner_cb,
-                      only_tags=only_tags, skip_tags=skip_tags, extra_vars=extra_vars)
+                      only_tags=only_tags, skip_tags=skip_tags, extra_vars=extra_vars,
+                      forks=3)
         playbook_result = pb.run()
         return playbook_result
 


### PR DESCRIPTION
- [x] Possibility to delete instances that were not created due to not enough quotas
- [x] Change ansible wait_for_ssh timeout to 10 minutes, as ~okeanos can be slow with big images
- [x] Limit ansible forks to 3
