### PR TITLE
Fix race condition for ip reservation

### DIFF
--- a/core/fokia/provisioner_base.py
+++ b/core/fokia/provisioner_base.py
@@ -189,10 +189,12 @@ class ProvisionerBase:
         Reserve ip
         :return: the ip object if successfull
         """
-        # list_float_ips = self.network_client.list_floatingips()
-        # for ip in list_float_ips:
-        #     if ip['instance_id'] is None and ip['port_id'] is None and ip not in ips:
-        #         return ip
+
+        list_float_ips = self.network_client.list_floatingips()
+        for ip in list_float_ips:
+            if ip['instance_id'] is None and ip['port_id'] is None:
+                return ip
+
         try:
             ip = self.network_client.create_floatingip(project_id=project_id)
             return ip


### PR DESCRIPTION
## Description

When a user creates 2 instances at the same time, there is a small chance that the fokia library will use the same ip for 2 different vms (since it will be run on different threads).
## Implementation

This fixes the issue by retrying, up to, 2 times to reserve an ip and use it for a vm creation.
