### PR TITLE
Fix for Pithos+ Upload Application Bug

### DIFF
--- a/ansible/roles/apache-flink/vars/main.yml
+++ b/ansible/roles/apache-flink/vars/main.yml
@@ -1,5 +1,5 @@
 ---
-mirror_url: "http://mirrors.myaegean.gr/apache/flink"
+mirror_url: "http://archive.apache.org/dist/flink"
 version: "0.9.1"
 version_for: "bin-hadoop27"
 download_path: "/root"

--- a/core/fokia/utils.py
+++ b/core/fokia/utils.py
@@ -148,7 +148,8 @@ def upload_file_to_pithos(auth_url, auth_token, container_name, project_id, loca
     :param auth_url: The authentication url for ~okeanos API.
     :param auth_token: The authentication token of the user.
     :param container_name: The name of the Pithos container to be used.
-    :param file_descriptor: A file descriptor of the file saved of the local file system.
+    :param project_id: The id of the ~okeanos project with the needed quotas.
+    :param local_file: A file descriptor on the local file system.
     """
 
     # Create Astakos client.

--- a/core/fokia/utils.py
+++ b/core/fokia/utils.py
@@ -142,7 +142,7 @@ def lambda_instance_stop(auth_url, auth_token, master_id, slave_ids):
         cyclades_compute_client.wait_server(slave_id, current_status="ACTIVE", max_wait=600)
 
 
-def upload_file_to_pithos(auth_url, auth_token, container_name, project_name, local_file):
+def upload_file_to_pithos(auth_url, auth_token, container_name, project_id, local_file):
     """
     Uploads a given file to a specified container, under a specified name on Pithos.
     :param auth_url: The authentication url for ~okeanos API.
@@ -158,12 +158,6 @@ def upload_file_to_pithos(auth_url, auth_token, container_name, project_name, lo
     pithos_url = astakos_client.get_endpoint_url(PithosClient.service_type)
     pithos_client = PithosClient(pithos_url, auth_token)
     pithos_client.account = astakos_client.user_info['id']
-
-    # Get the project id.
-    if project_name != "":
-        project_id = astakos_client.get_projects(**{'name': project_name})[0]['id']
-    else:
-        project_id = astakos_client.get_projects()[0]['id']
 
     # Choose the container on Pithos that is used to store application. If the container doesn't
     # exist, create it.

--- a/core/tests/test_utils.py
+++ b/core/tests/test_utils.py
@@ -294,7 +294,7 @@ def test_pithos_file_handling(mock_pithos, astakosclient, cycladesclient, mock_o
     file_obj = mock.Mock()
     pithosclient = mock_pithos.return_value
     mock_os.path.basename.return_value = "test_file_name"
-    utils.upload_file_to_pithos(url, token, container, "test_project_name", file_obj)
+    utils.upload_file_to_pithos(url, token, container, "test_project_id", file_obj)
     utils.download_file_from_pithos(url, token, container, filename, "test_destination")
     utils.delete_file_from_pithos(url, token, container, filename)
     pithosclient.upload_object.assert_called_with('test_file_name', file_obj)

--- a/webapp/backend/events.py
+++ b/webapp/backend/events.py
@@ -83,12 +83,13 @@ def insert_cluster_info(instance_uuid, specs, provisioner_response):
 
 
 @shared_task
-def create_new_application(uuid, name, path, description, app_type, owner,
+def create_new_application(uuid, name, project_id, path, description, app_type, owner,
                            execution_environment_name):
     """
     Creates a new entry of an application on the database.
     :param uuid: The uuid of the new application.
     :param name: The name of the new application.
+    :param project_id: The id of the ~okeanos project to be used.
     :param path: The path where the new application is stored on Pithos.
     :param description: The provided description of the new application.
     :param app_type: The type of the new application.
@@ -101,8 +102,8 @@ def create_new_application(uuid, name, path, description, app_type, owner,
     elif app_type == 'streaming':
         app_type = Application.STREAMING
 
-    Application.objects.create(uuid=uuid, name=name, path=path, description=description,
-                               owner=owner, type=app_type,
+    Application.objects.create(uuid=uuid, name=name, project_id=project_id, path=path,
+                               description=description, owner=owner, type=app_type,
                                execution_environment_name=execution_environment_name)
 
 

--- a/webapp/backend/exceptions.py
+++ b/webapp/backend/exceptions.py
@@ -26,7 +26,8 @@ class CustomParseError(APIException):
         'filter_value_error': "filter GET parameter can be used with values status or info.",
         'action_value_error': "action POST parameter can be used with start or stop value.",
         'no_type_error': "Wrong or no application type specified "
-                         "(correct choices: batch/streaming)."
+                         "(correct choices: batch/streaming).",
+        'no_project_error': "No ~okeanos project name provided."
     }
 
 

--- a/webapp/backend/exceptions.py
+++ b/webapp/backend/exceptions.py
@@ -76,6 +76,8 @@ class CustomCantDoError(APIException):
         'cant_do': "Can't {action} {object} while lambda instance status is {status}.",
         'delete_running_app': "Can't delete application {name} while it is running. "
                               "Current lambda instances it is running are: {instances}",
+        'wrong_project_name': "Can't use ~okeanos {project_name} project. You are not subscribed"
+                              " in it."
     }
 
 

--- a/webapp/backend/models.py
+++ b/webapp/backend/models.py
@@ -1,5 +1,5 @@
 from django.db import models
-import uuid
+from uuid import uuid4
 
 """
 OBJECTS
@@ -55,8 +55,11 @@ class Project(models.Model):
 
 class Application(models.Model):
     id = models.AutoField("id", primary_key=True, unique=True, help_text="Application id.")
-    uuid = models.UUIDField("uuid", unique=True, default=uuid.uuid4, help_text="Application uuid.")
+    uuid = models.UUIDField("uuid", unique=True, default=uuid4,
+                            help_text="Application uuid.")
     name = models.CharField(max_length=100, default="", null=True, blank=True)
+    project_id = models.UUIDField("project_id", unique=False, default=uuid4,
+                                  help_text="Project id.")
     path = models.CharField(max_length=400, default="lambda_applications")
     description = models.CharField(max_length=400, blank=True, default='')
     owner = models.ForeignKey(User, default=None, on_delete=models.SET_NULL, null=True, blank=True)

--- a/webapp/backend/tasks.py
+++ b/webapp/backend/tasks.py
@@ -333,7 +333,7 @@ setattr(create_lambda_instance, 'on_failure', on_failure)
 
 
 @shared_task
-def upload_application_to_pithos(auth_url, auth_token, container_name, project_name,
+def upload_application_to_pithos(auth_url, auth_token, container_name, project_id,
                                  local_file_path, application_uuid, application_name,
                                  application_description):
     """
@@ -355,7 +355,7 @@ def upload_application_to_pithos(auth_url, auth_token, container_name, project_n
     local_file = open(local_file_path, 'r')
 
     try:
-        utils.upload_file_to_pithos(auth_url, auth_token, container_name, project_name, local_file)
+        utils.upload_file_to_pithos(auth_url, auth_token, container_name, project_id, local_file)
 
         events.set_application_status.delay(application_uuid=application_uuid,
                                             status=Application.UPLOADED)

--- a/webapp/backend/views.py
+++ b/webapp/backend/views.py
@@ -290,8 +290,8 @@ class ApplicationViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
             raise CustomParseError(CustomParseError.messages['no_type_error'])
 
         # Get the name of the project provided and check if the user is subscribed on this project.
-        project_name = request.data.get('project_name', '')
-        if project_name == "":
+        project_name = request.data.get('project_name')
+        if not project_name:
             raise CustomParseError(CustomParseError.messages['no_project_error'])
 
         user_projects = get_user_okeanos_projects(auth_url, auth_token)

--- a/webapp/backend/views.py
+++ b/webapp/backend/views.py
@@ -291,6 +291,9 @@ class ApplicationViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
 
         # Get the name of the project provided and check if the user is subscribed on this project.
         project_name = request.data.get('project_name', '')
+        if project_name == "":
+            raise CustomParseError(CustomParseError.messages['no_project_error'])
+
         user_projects = get_user_okeanos_projects(auth_url, auth_token)
         chosen_project = None
         if project_name not in [project['name'] for project in user_projects]:

--- a/webapp/frontend/app/templates/lambda-apps/upload.hbs
+++ b/webapp/frontend/app/templates/lambda-apps/upload.hbs
@@ -48,11 +48,11 @@
               <div class="box-body">
                <div class="row">
         <div class="form-group col-sm-6">
-              <label for="okeanos_project" class="col-sm-6">~okeanos Project:</label>
+              <label for="project_name" class="col-sm-6">~okeanos Project:</label>
               <div class="col-sm-6">
 
 
-               <select name="okeanos_project" class="form-control">
+               <select name="project_name" class="form-control">
                  {{#each model.userOkeanosProjects as |project|}}
                    <option value={{project.name}}>{{project.name}} (pithos_space: {{normalize-bytes project.pithos_space}})</option>
                  {{/each}}

--- a/webapp/tests/test_celery_events.py
+++ b/webapp/tests/test_celery_events.py
@@ -124,20 +124,22 @@ class TestCeleryEvents(APITestCase):
     def test_create_new_application(self):
         application_uuid = uuid.uuid4()
         application_name = "application.jar"
+        project_id = uuid.uuid4()
         application_path = "application_path"
         application_description = "application_description"
         application_type = "batch"
         application_owner = User.objects.create(uuid=uuid.uuid4())
         application_execution_environment_name = "Stream"
 
-        events.create_new_application(application_uuid, application_name, application_path,
-                                      application_description, application_type,
+        events.create_new_application(application_uuid, application_name, project_id,
+                                      application_path, application_description, application_type,
                                       application_owner, application_execution_environment_name)
 
         self.assertEqual(Application.objects.all().count(), 1)
 
         application = Application.objects.get(uuid=application_uuid)
         self.assertEqual(application.name, application_name)
+        self.assertEqual(application.project_id, project_id)
         self.assertEqual(application.path, application_path)
         self.assertEqual(application.description, application_description)
         self.assertEqual(application.owner, application_owner)

--- a/webapp/tests/test_celery_tasks.py
+++ b/webapp/tests/test_celery_tasks.py
@@ -215,19 +215,19 @@ class TestCeleryTasks(APITestCase):
         application_name = "application_name"
         application_description = "application_description"
         container_name = "container_name"
-        project_name = "project_name"
+        project_id = uuid.uuid4()
         local_file_path = "local_file_path"
         application_uuid = uuid.uuid4()
 
         Application.objects.create(uuid=application_uuid, name=application_name,
-                                   path=container_name, description=application_description,
-                                   type=Application.BATCH)
+                                   project_id=project_id, path=container_name,
+                                   description=application_description, type=Application.BATCH)
 
         mock_local_file = mock.create_autospec(CustomFile())
         mock_builtin_open.return_value = mock_local_file
 
         tasks.upload_application_to_pithos(self.AUTHENTICATION_URL, self.AUTHENTICATION_TOKEN,
-                                           container_name, project_name, local_file_path,
+                                           container_name, project_id, local_file_path,
                                            application_uuid, application_name,
                                            application_description)
 
@@ -237,7 +237,7 @@ class TestCeleryTasks(APITestCase):
         mock_builtin_open.assert_called_with(local_file_path, 'r')
         mock_upload_file_to_pithos_fokia.assert_called_with(self.AUTHENTICATION_URL,
                                                             self.AUTHENTICATION_TOKEN,
-                                                            container_name, project_name,
+                                                            container_name, project_id,
                                                             mock_local_file)
         mock_set_application_status_event.delay. \
             assert_called_with(application_uuid=application_uuid, status=Application.UPLOADED)
@@ -264,19 +264,19 @@ class TestCeleryTasks(APITestCase):
         application_name = "application_name"
         application_description = "application_description"
         container_name = "container_name"
-        project_name = "project_name"
+        project_id = uuid.uuid4()
         local_file_path = "local_file_path"
         application_uuid = uuid.uuid4()
 
         Application.objects.create(uuid=application_uuid, name=application_name,
-                                   path=container_name, description=application_description,
-                                   type=Application.BATCH)
+                                   project_id=project_id, path=container_name,
+                                   description=application_description, type=Application.BATCH)
 
         mock_local_file = mock.create_autospec(CustomFile())
         mock_builtin_open.return_value = mock_local_file
 
         tasks.upload_application_to_pithos(self.AUTHENTICATION_URL, self.AUTHENTICATION_TOKEN,
-                                           container_name, project_name, local_file_path,
+                                           container_name, project_id, local_file_path,
                                            application_uuid, application_name,
                                            application_description)
 
@@ -286,7 +286,7 @@ class TestCeleryTasks(APITestCase):
         mock_builtin_open.assert_called_with(local_file_path, 'r')
         mock_upload_file_to_pithos_fokia.assert_called_with(self.AUTHENTICATION_URL,
                                                             self.AUTHENTICATION_TOKEN,
-                                                            container_name, project_name,
+                                                            container_name, project_id,
                                                             mock_local_file)
         mock_set_application_status_event.delay. \
             assert_called_with(application_uuid, Application.FAILED, "exception-message")


### PR DESCRIPTION
# Description

Pithos+ assigns an ~okeanos project on each container. With the current implementation, a single container is used and the project assigned on it is the project that the user chooses for the first application.
# Fix

Each ~okeanos project that the user chooses to use quotas from, will have its own Pithos+ container.
