### PR TITLE
Remove deleted items from lists on ember model refresh

### DIFF
--- a/webapp/frontend/app/controllers/lambda-apps/index.js
+++ b/webapp/frontend/app/controllers/lambda-apps/index.js
@@ -63,9 +63,6 @@ export default Ember.ArrayController.extend({
               _this.set('success_delete', true);
               _this.set('delete_success_message', 'Your request to delete the application was successfully sent to the server.');
               Ember.run.later((function () {
-                _this.store.find('lambda-app', app_id).then(function (application) {
-                  _this.store.unloadRecord(application);
-                });
                 _this.set('success_delete', false);
               }), ENV.message_dismiss);
             },

--- a/webapp/frontend/app/controllers/lambda-instances/index.js
+++ b/webapp/frontend/app/controllers/lambda-instances/index.js
@@ -66,9 +66,6 @@ export default Ember.ArrayController.extend({
             _this.set('success_delete', true);
             _this.set('delete_success_message', 'Your request to delete the lambda instance was successfully sent to the server.');
             Ember.run.later((function () {
-              _this.store.find('lambda-instance', instance_id).then(function (instance) {
-                _this.store.unloadRecord(instance);
-              });
               _this.set('success_delete', false);
             }), ENV.message_dismiss);
           },

--- a/webapp/frontend/app/serializers/application.js
+++ b/webapp/frontend/app/serializers/application.js
@@ -25,7 +25,7 @@ export default DS.JSONAPISerializer.extend({
     var oldRecords = this.store.peekAll(modelName);
     var record;
     oldRecords.forEach (function (oldRecord) {
-      if (!payload.data.isAny('id', oldRecord.id)) {
+      if (!payload.isAny('id', oldRecord.id)) {
         record = store.peekRecord(modelName, oldRecord.id);
         store.unloadRecord(record);
       }

--- a/webapp/frontend/app/serializers/application.js
+++ b/webapp/frontend/app/serializers/application.js
@@ -19,6 +19,17 @@ export default DS.JSONAPISerializer.extend({
   normalizeSingleResponse: function (store, primaryModelClass, payload, id, requestType) {
     payload.data = payload.data[0];
     return this._super(store, primaryModelClass, payload, id, requestType);
-  }
+  },
+
+  removeDeleted: function (store, modelName, payload) {
+    var oldRecords = this.store.peekAll(modelName);
+    var record;
+    oldRecords.forEach (function (oldRecord) {
+      if (!payload.data.isAny('id', oldRecord.id)) {
+        record = store.peekRecord(modelName, oldRecord.id);
+        store.unloadRecord(record);
+      }
+    });
+  },
 
 });

--- a/webapp/frontend/app/serializers/lambda-app.js
+++ b/webapp/frontend/app/serializers/lambda-app.js
@@ -23,6 +23,7 @@ export default LoDSerializer.extend(DS.EmbeddedRecordsMixin, {
        }
     }
     payload.included = payload.data[0].attributes.lambda_instances;
+    this.removeDeleted(store, 'lambda-instance', payload.included);
     delete payload.data[0].attributes.lambda_instances;
     delete payload.data[0].attributes.status;
     return this._super(store, primaryModelClass, payload, id, requestType);
@@ -36,7 +37,7 @@ export default LoDSerializer.extend(DS.EmbeddedRecordsMixin, {
         payload.data[i].attributes[key] = payload.data[i].attributes.status[k];
       }
     }
-    this.removeDeleted(store, primaryModelClass.modelName, payload);
+    this.removeDeleted(store, primaryModelClass.modelName, payload.data);
     return this._super(store, primaryModelClass, payload, id, requestType);
   }
 });

--- a/webapp/frontend/app/serializers/lambda-app.js
+++ b/webapp/frontend/app/serializers/lambda-app.js
@@ -36,6 +36,7 @@ export default LoDSerializer.extend(DS.EmbeddedRecordsMixin, {
         payload.data[i].attributes[key] = payload.data[i].attributes.status[k];
       }
     }
+    this.removeDeleted(store, primaryModelClass.modelName, payload);
     return this._super(store, primaryModelClass, payload, id, requestType);
   }
 });

--- a/webapp/frontend/app/serializers/lambda-instance.js
+++ b/webapp/frontend/app/serializers/lambda-instance.js
@@ -22,6 +22,7 @@ export default LoDSerializer.extend(DS.EmbeddedRecordsMixin, {
       payload.data[0].applications[k].attributes = Ember.$.extend(true, {}, payload.data[0].applications[k]);
     }
     payload.included = payload.data[0].applications;
+    this.removeDeleted(store, 'lambda-app', payload.included);
     delete payload.data[0].attributes.applications;
     delete payload.data[0].attributes.info;
     delete payload.data[0].attributes.status;
@@ -35,7 +36,7 @@ export default LoDSerializer.extend(DS.EmbeddedRecordsMixin, {
         payload.data[i].attributes[key] = payload.data[i].attributes.status[k];
       }
     }
-    this.removeDeleted(store, primaryModelClass.modelName, payload);
+    this.removeDeleted(store, primaryModelClass.modelName, payload.data);
     return this._super(store, primaryModelClass, payload, id, requestType);
   }
 });

--- a/webapp/frontend/app/serializers/lambda-instance.js
+++ b/webapp/frontend/app/serializers/lambda-instance.js
@@ -35,6 +35,7 @@ export default LoDSerializer.extend(DS.EmbeddedRecordsMixin, {
         payload.data[i].attributes[key] = payload.data[i].attributes.status[k];
       }
     }
+    this.removeDeleted(store, primaryModelClass.modelName, payload);
     return this._super(store, primaryModelClass, payload, id, requestType);
   }
 });


### PR DESCRIPTION
## Task description

Currently, the function `findAll` ember uses to fetch an array of records does not delete records that were deleted on the backend model, but exist in ember's model. This is not desired, as we want deleted items not to appear on the lists.
## Implementation details

The current task implements the function `removeDeleted` in the ember application serializer. This function compares the records residing in the ember model, with the new payload received from the API. If a record is found to be existing in the ember model, but not in the backend model, the function unloads the record from the ember model. The `removeDeleted` function is called from the `normalizeArrayResponse` function of the lambda instance and lambda application serializers.
