### PR TITLE
Service VM communication with Central VM

### DIFF
--- a/webapp/ansible/roles/service-vm/templates/settings.py.j2
+++ b/webapp/ansible/roles/service-vm/templates/settings.py.j2
@@ -210,6 +210,10 @@ CELERY_ROUTES = {
         'queue': 'statistics_queue',
         'routing_key': 'statistics_key',
     },
+    'backend.central_vm_tasks.register_user_central_vm': {
+        'queue': 'statistics_queue',
+        'routing_key': 'statistics_key',
+    },
     'backend.events.set_lambda_instance_status': {
         'queue': 'events_queue',
         'routing_key': 'event_key',

--- a/webapp/ansible/roles/service-vm/templates/settings.py.j2
+++ b/webapp/ansible/roles/service-vm/templates/settings.py.j2
@@ -202,6 +202,14 @@ CELERY_ROUTES = {
         'queue': 'statistics_queue',
         'routing_key': 'statistics_key',
     },
+    'backend.central_vm_tasks.increment_started_counter_central_vm': {
+        'queue': 'statistics_queue',
+        'routing_key': 'statistics_key',
+    },
+    'backend.central_vm_tasks.decrement_started_counter_central_vm': {
+        'queue': 'statistics_queue',
+        'routing_key': 'statistics_key',
+    },
     'backend.events.set_lambda_instance_status': {
         'queue': 'events_queue',
         'routing_key': 'event_key',

--- a/webapp/backend/central_vm_tasks.py
+++ b/webapp/backend/central_vm_tasks.py
@@ -207,3 +207,21 @@ def decrement_started_counter_central_vm(self, auth_token, application_uuid):
             })
     except (requests.exceptions.Timeout, requests.exceptions.ConnectionError):
         self.retry(countdown=settings.CENTRAL_VM_RETRY_COUNTDOWN)
+
+
+@shared_task(bind=True)
+def register_user_central_vm(self, auth_token):
+    """
+    Makes an HTTP request to Central VM to register the user.
+    :param auth_token: The authentication token of the user to be registered.
+    """
+
+    # Make a get request to Central VM. Note that in case of a timeout, there will be no retries
+    # since the registering of the user can be done the next time he/she logs in, creates a new
+    # Lambda Instance or uploads an Application.
+    requests.get(
+        url=settings.CENTRAL_VM_API + "/authenticate/",
+        headers={
+            'Authorization': "Token {}".format(auth_token),
+        }
+    )

--- a/webapp/backend/central_vm_tasks.py
+++ b/webapp/backend/central_vm_tasks.py
@@ -161,3 +161,49 @@ def delete_application_central_vm(self, auth_token, application_uuid):
             })
     except (requests.exceptions.Timeout, requests.exceptions.ConnectionError):
         self.retry(countdown=settings.CENTRAL_VM_RETRY_COUNTDOWN)
+
+
+@shared_task(bind=True)
+def increment_started_counter_central_vm(self, auth_token, application_uuid):
+    """
+    Makes an HTTP request to Central VM to increment the times_started counter of the specified
+    Application.
+    :param auth_token: The authentication token of the user that owns the Application.
+    :param application_uuid: The uuid of the Application.
+    """
+
+    # Make a POST request to Central VM. In case of a timeout, retry three(3)
+    # times(default Celery retry) and then stop trying.
+
+    try:
+        requests.post(
+            url=(settings.CENTRAL_VM_API + "/lambda_applications/{}/increment_started/").format(
+                application_uuid),
+            headers={
+                'Authorization': "Token {}".format(auth_token),
+            })
+    except (requests.exceptions.Timeout, requests.exceptions.ConnectionError):
+        self.retry(countdown=settings.CENTRAL_VM_RETRY_COUNTDOWN)
+
+
+@shared_task(bind=True)
+def decrement_started_counter_central_vm(self, auth_token, application_uuid):
+    """
+    Makes an HTTP request to Central Vm to increment the times_started counter of the specified
+    Application.
+    :param auth_token: The authentication token of the user that owns the Application.
+    :param application_uuid: The uuid of the Application.
+    """
+
+    # Make a POST request to Central VM. In case of a timeout, retry three(3)
+    # times(default Celery retry) and then stop trying.
+
+    try:
+        requests.post(
+            url=(settings.CENTRAL_VM_API + "/lambda_applications/{}/decrement_started/").format(
+                application_uuid),
+            headers={
+                'Authorization': "Token {}".format(auth_token),
+            })
+    except (requests.exceptions.Timeout, requests.exceptions.ConnectionError):
+        self.retry(countdown=settings.CENTRAL_VM_RETRY_COUNTDOWN)

--- a/webapp/backend/views.py
+++ b/webapp/backend/views.py
@@ -108,6 +108,9 @@ def authenticate(request):
     authenticator = KamakiTokenAuthentication()
     user = authenticator.authenticate_credentials(auth_token)[0]
 
+    # Create a Celery task that will register the user on the Central VM.
+    central_vm_tasks.register_user_central_vm.delay(auth_token)
+
     status_code = status.HTTP_200_OK
     return Response({"status": status_code,
                      "result": "Success",

--- a/webapp/tests/test_applications.py
+++ b/webapp/tests/test_applications.py
@@ -1346,8 +1346,10 @@ class TestApplicationStart(APITestCase):
             create(application=self.application, lambda_instance=self.lambda_instance)
 
     # Test for starting an application on a specified lambda instance that it is already deployed.
+    @mock.patch('backend.views.central_vm_tasks.increment_started_counter_central_vm')
     @mock.patch('backend.views.tasks.start_stop_application')
-    def test_application_start_batch(self, mock_start_stop_application_task):
+    def test_application_start_batch(self, mock_start_stop_application_task,
+                                     mock_increment_started_counter_central_vm):
         # Make a request to start the application.
         response = self.client.post("/api/apps/{application_uuid}/start/".
                                       format(application_uuid=self.application_uuid),
@@ -1375,10 +1377,14 @@ class TestApplicationStart(APITestCase):
                                app_action="start", app_type="batch",
                                jar_filename="application.jar",
                                execution_environment_name="Stream")
+        mock_increment_started_counter_central_vm.delay.\
+            assert_called_with(self.AUTHENTICATION_TOKEN, "{}".format(self.application_uuid))
 
     # Test for starting an application on a specified lambda instance that it is already deployed.
+    @mock.patch('backend.views.central_vm_tasks.increment_started_counter_central_vm')
     @mock.patch('backend.views.tasks.start_stop_application')
-    def test_application_start_streaming(self, mock_start_stop_application_task):
+    def test_application_start_streaming(self, mock_start_stop_application_task,
+                                         mock_increment_started_counter_central_vm):
         # Change the type of the application from batch to streaming.
         self.application.type = Application.STREAMING
         self.application.save()
@@ -1410,6 +1416,8 @@ class TestApplicationStart(APITestCase):
                                app_action="start", app_type="streaming",
                                jar_filename="application.jar",
                                execution_environment_name="Stream")
+        mock_increment_started_counter_central_vm.delay.\
+            assert_called_with(self.AUTHENTICATION_TOKEN, "{}".format(self.application_uuid))
 
     # Test for request to start an application when the lambda instance id is not provided.
     def test_no_lambda_instance_id(self):
@@ -1653,8 +1661,10 @@ class TestApplicationStop(APITestCase):
                    started=True)
 
     # Test for stopping an application on a specified lambda instance that it is already started.
+    @mock.patch('backend.views.central_vm_tasks.decrement_started_counter_central_vm')
     @mock.patch('backend.views.tasks.start_stop_application')
-    def test_application_stop_batch(self, mock_start_stop_application_task):
+    def test_application_stop_batch(self, mock_start_stop_application_task,
+                                    mock_decrement_started_counter_central_vm):
         # Make a request to stop the application.
         response = self.client.post("/api/apps/{application_uuid}/stop/".
                                       format(application_uuid=self.application_uuid),
@@ -1681,10 +1691,14 @@ class TestApplicationStop(APITestCase):
                                format(application_id=self.application_uuid),
                                app_action="stop", app_type="batch",
                                execution_environment_name="Stream")
+        mock_decrement_started_counter_central_vm.delay.\
+            assert_called_with(self.AUTHENTICATION_TOKEN, "{}".format(self.application_uuid))
 
     # Test for stopping an application on a specified lambda instance that it is already started.
+    @mock.patch('backend.views.central_vm_tasks.decrement_started_counter_central_vm')
     @mock.patch('backend.views.tasks.start_stop_application')
-    def test_application_stop_streaming(self, mock_start_stop_application_task):
+    def test_application_stop_streaming(self, mock_start_stop_application_task,
+                                        mock_decrement_started_counter_central_vm):
         # Change the type of the application from batch to streaming.
         self.application.type = Application.STREAMING
         self.application.save()
@@ -1715,6 +1729,8 @@ class TestApplicationStop(APITestCase):
                                format(application_id=self.application_uuid),
                                app_action="stop", app_type="streaming",
                                execution_environment_name="Stream")
+        mock_decrement_started_counter_central_vm.delay.\
+            assert_called_with(self.AUTHENTICATION_TOKEN, "{}".format(self.application_uuid))
 
     # Test for request to stop an application when the lambda instance id is not provided.
     def test_no_lambda_instance_id(self):

--- a/webapp/tests/test_celery_central_vm_tasks.py
+++ b/webapp/tests/test_celery_central_vm_tasks.py
@@ -673,3 +673,196 @@ class TestCeleryCentralVMTasks(APITestCase):
 
         central_vm_tasks.delete_application_central_vm.retry.\
             assert_called_with(countdown=mock_settings.CENTRAL_VM_RETRY_COUNTDOWN)
+
+    @mock.patch('backend.central_vm_tasks.settings')
+    @mock.patch('backend.central_vm_tasks.requests')
+    def test_increment_started_counter_central_vm(self, mock_requests, mock_settings):
+        # Set the required values for the mocks.
+        mock_settings.CENTRAL_VM_API = "CENTRAL_VM_API"
+
+        # Create the parameters that will be given as input to the task.
+        application_uuid = uuid.uuid4()
+
+        # Call the task.
+        central_vm_tasks.increment_started_counter_central_vm(self.AUTHENTICATION_TOKEN,
+                                                              application_uuid)
+
+        # Assert that the proper mock calls have been made.
+        mock_requests.post.assert_called_with(
+            url="CENTRAL_VM_API/lambda_applications/{}/increment_started/".format(application_uuid),
+            headers={
+                'Authorization': "Token {}".format(self.AUTHENTICATION_TOKEN),
+            }
+        )
+
+    @mock.patch('backend.central_vm_tasks.requests.exceptions.Timeout', new=CustomTimeoutException)
+    @mock.patch('backend.central_vm_tasks.settings')
+    @mock.patch('backend.central_vm_tasks.requests')
+    def test_increment_started_counter_central_vm_timeout_except(self, mock_requests,
+                                                                 mock_settings):
+        # Set side effects for mocks.
+        mock_requests.post.side_effect = CustomTimeoutException()
+
+        # Set the required values for the mocks.
+        mock_settings.CENTRAL_VM_API = "CENTRAL_VM_API"
+        mock_settings.CENTRAL_VM_RETRY_COUNTDOWN = "CENTRAL_VM_RETRY_COUNTDOWN"
+
+        # Create the parameters that will be given as input to the task.
+        instance_uuid = uuid.uuid4()
+
+        # Mock retry method of the task to be called.
+        central_vm_tasks.increment_started_counter_central_vm.retry = mock.Mock()
+
+        # Call the task.
+        central_vm_tasks.increment_started_counter_central_vm(self.AUTHENTICATION_TOKEN,
+                                                              instance_uuid)
+
+        # Assert that the proper mock calls have been made.
+        mock_requests.post.assert_called_with(
+            url="CENTRAL_VM_API/lambda_applications/{}/increment_started/".format(instance_uuid),
+            headers={
+                'Authorization': "Token {}".format(self.AUTHENTICATION_TOKEN),
+            }
+        )
+
+        central_vm_tasks.increment_started_counter_central_vm.retry.\
+            assert_called_with(countdown=mock_settings.CENTRAL_VM_RETRY_COUNTDOWN)
+
+    @mock.patch('backend.central_vm_tasks.requests.exceptions.ConnectionError',
+                new=CustomConnectionError)
+    @mock.patch('backend.central_vm_tasks.settings')
+    @mock.patch('backend.central_vm_tasks.requests')
+    def test_increment_started_counter_central_vm_connection_error_except(self, mock_requests,
+                                                                          mock_settings):
+        # Set side effects for mocks.
+        mock_requests.post.side_effect = CustomConnectionError()
+
+        # Set the required values for the mocks.
+        mock_settings.CENTRAL_VM_API = "CENTRAL_VM_API"
+        mock_settings.CENTRAL_VM_RETRY_COUNTDOWN = "CENTRAL_VM_RETRY_COUNTDOWN"
+
+        # Create the parameters that will be given as input to the task.
+        application_uuid = uuid.uuid4()
+
+        # Mock retry method of the task to be called.
+        central_vm_tasks.increment_started_counter_central_vm.retry = mock.Mock()
+
+        # Call the task.
+        central_vm_tasks.increment_started_counter_central_vm(self.AUTHENTICATION_TOKEN,
+                                                              application_uuid)
+
+        # Assert that the proper mock calls have been made.
+        mock_requests.post.assert_called_with(
+            url="CENTRAL_VM_API/lambda_applications/{}/increment_started/".format(application_uuid),
+            headers={
+                'Authorization': "Token {}".format(self.AUTHENTICATION_TOKEN),
+            }
+        )
+
+        central_vm_tasks.increment_started_counter_central_vm.retry.\
+            assert_called_with(countdown=mock_settings.CENTRAL_VM_RETRY_COUNTDOWN)
+
+    @mock.patch('backend.central_vm_tasks.settings')
+    @mock.patch('backend.central_vm_tasks.requests')
+    def test_decrement_started_counter_central_vm(self, mock_requests, mock_settings):
+        # Set the required values for the mocks.
+        mock_settings.CENTRAL_VM_API = "CENTRAL_VM_API"
+
+        # Create the parameters that will be given as input to the task.
+        application_uuid = uuid.uuid4()
+
+        # Call the task.
+        central_vm_tasks.decrement_started_counter_central_vm(self.AUTHENTICATION_TOKEN,
+                                                              application_uuid)
+
+        # Assert that the proper mock calls have been made.
+        mock_requests.post.assert_called_with(
+            url="CENTRAL_VM_API/lambda_applications/{}/decrement_started/".format(application_uuid),
+            headers={
+                'Authorization': "Token {}".format(self.AUTHENTICATION_TOKEN),
+            }
+        )
+
+    @mock.patch('backend.central_vm_tasks.requests.exceptions.Timeout', new=CustomTimeoutException)
+    @mock.patch('backend.central_vm_tasks.settings')
+    @mock.patch('backend.central_vm_tasks.requests')
+    def test_decrement_started_counter_central_vm_timeout_except(self, mock_requests,
+                                                                 mock_settings):
+        # Set side effects for mocks.
+        mock_requests.post.side_effect = CustomTimeoutException()
+
+        # Set the required values for the mocks.
+        mock_settings.CENTRAL_VM_API = "CENTRAL_VM_API"
+        mock_settings.CENTRAL_VM_RETRY_COUNTDOWN = "CENTRAL_VM_RETRY_COUNTDOWN"
+
+        # Create the parameters that will be given as input to the task.
+        instance_uuid = uuid.uuid4()
+
+        # Mock retry method of the task to be called.
+        central_vm_tasks.decrement_started_counter_central_vm.retry = mock.Mock()
+
+        # Call the task.
+        central_vm_tasks.decrement_started_counter_central_vm(self.AUTHENTICATION_TOKEN,
+                                                              instance_uuid)
+
+        # Assert that the proper mock calls have been made.
+        mock_requests.post.assert_called_with(
+            url="CENTRAL_VM_API/lambda_applications/{}/decrement_started/".format(instance_uuid),
+            headers={
+                'Authorization': "Token {}".format(self.AUTHENTICATION_TOKEN),
+            }
+        )
+
+        central_vm_tasks.decrement_started_counter_central_vm.retry.\
+            assert_called_with(countdown=mock_settings.CENTRAL_VM_RETRY_COUNTDOWN)
+
+    @mock.patch('backend.central_vm_tasks.requests.exceptions.ConnectionError',
+                new=CustomConnectionError)
+    @mock.patch('backend.central_vm_tasks.settings')
+    @mock.patch('backend.central_vm_tasks.requests')
+    def test_decrement_started_counter_central_vm_connection_error_except(self, mock_requests,
+                                                                          mock_settings):
+        # Set side effects for mocks.
+        mock_requests.post.side_effect = CustomConnectionError()
+
+        # Set the required values for the mocks.
+        mock_settings.CENTRAL_VM_API = "CENTRAL_VM_API"
+        mock_settings.CENTRAL_VM_RETRY_COUNTDOWN = "CENTRAL_VM_RETRY_COUNTDOWN"
+
+        # Create the parameters that will be given as input to the task.
+        application_uuid = uuid.uuid4()
+
+        # Mock retry method of the task to be called.
+        central_vm_tasks.decrement_started_counter_central_vm.retry = mock.Mock()
+
+        # Call the task.
+        central_vm_tasks.decrement_started_counter_central_vm(self.AUTHENTICATION_TOKEN,
+                                                              application_uuid)
+
+        # Assert that the proper mock calls have been made.
+        mock_requests.post.assert_called_with(
+            url="CENTRAL_VM_API/lambda_applications/{}/decrement_started/".format(application_uuid),
+            headers={
+                'Authorization': "Token {}".format(self.AUTHENTICATION_TOKEN),
+            }
+        )
+
+        central_vm_tasks.decrement_started_counter_central_vm.retry.\
+            assert_called_with(countdown=mock_settings.CENTRAL_VM_RETRY_COUNTDOWN)
+
+    @mock.patch('backend.central_vm_tasks.settings')
+    @mock.patch('backend.central_vm_tasks.requests')
+    def test_register_user_central_vm_central_vm(self, mock_requests, mock_settings):
+        # Set the required values for the mocks.
+        mock_settings.CENTRAL_VM_API = "CENTRAL_VM_API"
+
+        # Call the task.
+        central_vm_tasks.register_user_central_vm(self.AUTHENTICATION_TOKEN)
+
+        # Assert that the proper mock calls have been made.
+        mock_requests.get.assert_called_with(
+            url="CENTRAL_VM_API/authenticate/",
+            headers={
+                'Authorization': "Token {}".format(self.AUTHENTICATION_TOKEN),
+            }
+        )


### PR DESCRIPTION
# Description

Two modifications are made with this pull request.
1. The Service VM logs information regarding the times an application has been started or stopped on Central VM.
2. The Service VM registers a user on log in addition to when creating a Lambda Instance or uploading an Application.
