### PR TITLE
~okeanos non-active-projects-returned bug

### DIFF
--- a/core/fokia/utils.py
+++ b/core/fokia/utils.py
@@ -232,6 +232,9 @@ def get_user_okeanos_projects(auth_url, auth_token):
     okeanos_projects = list()
 
     for okeanos_project in astakos_client.get_projects():
+        if okeanos_project['state'] != 'active':
+            continue
+
         project_id = okeanos_project['id']
         project_name = okeanos_project['name']
 

--- a/core/tests/test_utils.py
+++ b/core/tests/test_utils.py
@@ -18,8 +18,9 @@ def test_get_user_okeanos_projects(mock_AstakosClient):
     mock_AstakosClient.return_value = mock_astakos_client
 
     mock_astakos_client.get_projects.return_value = [
-        {'id': '1', 'name': "name1", 'garbage': 'garbage'},
-        {'id': '2', 'name': "name2", 'garbage2': 'garbage2'}]
+        {'id': '1', 'name': "name1", 'state': 'active', 'garbage': 'garbage'},
+        {'id': '2', 'name': "name2", 'state': 'active', 'garbage2': 'garbage2'},
+        {'id': '3', 'name': "name3", 'state': 'deleted', 'garbage3': 'garbage3'}]
 
     mock_astakos_client.get_quotas.return_value = {
         '1': {


### PR DESCRIPTION
## Description

The `get_projects()` call from AstakosClient returns all the projects that the user is registered. Not every of these projects is active. The `get_quotas()` call from AstakosClient returns the quotas only for the active projects that the user is registered. The above situation leads to errors, when the API tries to find the quotas of a non-active project.
## Solution

The API will ignore non-active projects and work only with the active ones.
