### PR TITLE
Use ansible version 1.9.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_install:
  - "npm install -g npm@^2"
 
 install: 
- - pip install tox ansible flake8-diff
+ - pip install tox ansible==1.9.4 flake8-diff
  - cd webapp/frontend/
  - npm install -g bower
  - npm install

--- a/core/requirements.txt
+++ b/core/requirements.txt
@@ -1,5 +1,5 @@
 kamaki>=0.13.4
-ansible>=1.9.2
+ansible==1.9.4
 crypto>=1.4.1
 pycrypto>=2.6.1
 stormssh>=0.6.5


### PR DESCRIPTION
## Description

When running `pip install ansible`, Ansible version 2.0.0 gets installed. In this version, class `ansible.playbook.PlayBook` is renamed to `ansible.playbook.Playbook` (notice lower b) thus breaking some imports.
## Solution

Use Ansible version 1.9.4.
