### PR TITLE
Upgrade cffi package before installing Fokia requirements

### DIFF
--- a/webapp/ansible/roles/service-vm/tasks/main.yml
+++ b/webapp/ansible/roles/service-vm/tasks/main.yml
@@ -19,6 +19,9 @@
   - name: Change repository permissions.
     file: path={{ repository_download_path }} owner=celery group=celery recurse=yes
 
+  - name: Upgrade cffi package
+    command: pip install --upgrade cffi
+
   - name: Install Fokia requirements.
     pip: requirements={{ repository_download_path }}/okeanos-LoD/core/requirements.txt
 


### PR DESCRIPTION
Upgrade cffi package before installing Fokia requirements, to resolve the `ImportError: No module named setuptools_ext` pip issue.
