### PR TITLE
Fix kamaki version to 0.13.4

### DIFF
--- a/core/requirements.txt
+++ b/core/requirements.txt
@@ -1,4 +1,4 @@
-kamaki>=0.13.4
+kamaki==0.13.4
 ansible==1.9.4
 crypto>=1.4.1
 pycrypto>=2.6.1


### PR DESCRIPTION
## Description

A new version for kamaki is available (0.13.5). In the new version, when astakos client authenticate method is called with an invalid token, an AstakosClientError is thrown instead of a ClientError causing a failure at: https://github.com/grnet/okeanos-LoD/blob/devel/core/fokia/utils.py#L72

The result is that, when using the okeanos-LoD API with an invalid token, a 500 internal server error is returned instead of a 401 Unathorized.
